### PR TITLE
Add：送信相手と手紙のidを保存する機能を追加

### DIFF
--- a/app/controllers/send_letters_controller.rb
+++ b/app/controllers/send_letters_controller.rb
@@ -1,4 +1,7 @@
 class SendLettersController < ApplicationController
+  require 'net/http'
+  require 'uri'
+
   def index
   end
 
@@ -9,6 +12,15 @@ class SendLettersController < ApplicationController
   end
 
   def create
+    idToken = params[:idToken]
+    channelId = ENV['CHANNEL_ID']
+    res = Net::HTTP.post_form(URI.parse('https://api.line.me/oauth2/v2.1/verify'),
+                          {'id_token'=>idToken, 'client_id'=>channelId})
+    render :json => res.body
+    destination_id = params[:dataId]
+    letter = Letter.find_by(token: params[:letterToken])
+    send_letter = SendLetter.new(destination_id: destination_id ,letter_id: letter.id)
+    send_letter.save! if SendLetter.find_by(letter_id: letter.id) == nil
   end
 
   def edit

--- a/app/javascript/packs/letters/invite.js
+++ b/app/javascript/packs/letters/invite.js
@@ -1,0 +1,59 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const token = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+
+  const LIFF_ID = process.env.LIFF_ID
+  liff.init({
+    liffId: LIFF_ID
+  })
+    .then(() => {
+      if (!liff.isLoggedIn()) {
+        liff.login();
+      }
+    })
+    .then(() => {
+
+      const idToken = liff.getIDToken()
+      const body = `idToken=${idToken}`
+      const request = new Request('/users', {
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8',
+          'X-CSRF-Token': token
+        },
+        method: 'POST',
+        body: body
+      });
+
+      fetch(request)
+        .then(response => response.json())
+        .then(data => {
+          dataId = data.id
+        })
+        .then(() => {
+          const postFormElm = document.querySelector('#ok')
+          postFormElm.addEventListener('ajax:success', (e) => {
+            const letterToken = e.detail[0].token
+            const data = `idToken=${idToken}&dataId=${dataId}&letterToken=${letterToken}`
+            const req = new Request('/send_letters', {
+              headers: {
+                'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8',
+                'X-CSRF-Token': token
+              },
+              method: 'POST',
+              body: data
+            });
+
+            fetch(req)
+              .then(response => response.json())
+              .then(data => {
+                data_id = data.id
+              })
+              .then(() => {
+                liff.closeWindow();
+              })
+              .catch((err) => {
+                console.log(err.code, err.message);
+              });
+          })
+        })
+    })
+})

--- a/app/javascript/packs/letters/new.js
+++ b/app/javascript/packs/letters/new.js
@@ -37,12 +37,12 @@ document.addEventListener('DOMContentLoaded', () => {
     liff.shareTargetPicker([
       message = {
         "type": "template",
-        "altText": "お手紙が届いています。",
+        "altText": "メッセージが届いています。",
         "template": {
-            "thumbnailImageUrl": "https://s4.aconvert.com/convert/p3r68-cdx67/a6pzu-mzopp.jpg",
+          "thumbnailImageUrl": "https://photo-cdn2.icons8.com/brt9x13Zw6j73rN4WiO7eJAicpfu_uWitaTeSYif2TM/rs:fit:1606:1072/czM6Ly9pY29uczgu/bW9vc2UtcHJvZC5h/c3NldHMvYXNzZXRz/L3NhdGEvb3JpZ2lu/YWwvMTYxLzIzNDE3/N2IzLWRmZWEtNDI2/Yi1hZGZkLWE0NjZl/YzgzMTRkZC5qcGc.jpg",
             "type": "buttons",
             "title": "お手紙",
-            "text": "お手紙を書きました！",
+            "text": "宛先を確認してください！",
             "actions": [
                 {
                   "type": "uri",

--- a/app/views/letters/invite.html.slim
+++ b/app/views/letters/invite.html.slim
@@ -1,0 +1,18 @@
+= javascript_pack_tag 'letters/invite'
+
+div.text-blue-900.main-font.text-1xl.tracking-wider.text-center
+  p
+    | サプライズでお手紙を送りたいです。
+  p
+    | 表示されているお名前が正しければ
+  p
+    | 「OK」を押してください。
+
+div.text-center.leading-5
+  div.shadow-lg.w-auto
+    div.w-full
+      = image_tag('tulip.jpg')
+    div.text-blue-900.main-font.text-1xl.px-4.py-2
+      = @letter.title
+div.text-blue-900.m-5.font.text-center
+  = link_to "OK", reserve_letter_path(@letter.id), id: 'ok', remote: true, data: { confirm: 'サプライズで手紙が届きます。よろしいですか?' }, class: "m-3 bg-pink-100 hover:bg-pink-200 rounded-full py-2 px-4"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,13 +3,17 @@ Rails.application.routes.draw do
   root 'users#new'
 
   resources :users, only: %i[create]
-  resources :letters, only: %i[create new update edit index destroy]
+  resources :letters, only: %i[create new update edit index destroy reserve] do
+    member do
+      get 'reserve'
+    end
+  end
   resources :send_letters
 
   # get 'login', to: 'users#new'
   get 'open', to: 'letters#open'
   get 'message', to: 'letters#message'
-  get 'letters/:token', to: 'letters#show'
+  get 'letters/:token', to: 'letters#invite'
   get 'privacy', to: 'home#privacy'
   get 'terms', to: 'home#terms'
   get 'description', to: 'home#description'


### PR DESCRIPTION
## 概要

送信相手と手紙のidを `send_letters`へ保存できるようにしました。 0df8e6b3c106c2324e6156cd078b4b39e173a924
また、トーク画面に表示されるメッセージの内容を修正しました。 a3238cef0448dccefb0586a5457b3b2ac58490da

## 確認方法

1. 手紙作成ページからターゲットピッカーを開いて相手へ手紙の送信申請を送信できることをご確認ください。
2. 送信相手は送信申請を開くことができ、宛先の確認をした後にOKボタンを押すことができることをご確認ください。
3. OKボタンを押した場合、 `send_letters`へ手紙のidと送信相手のidが保存されることをご確認ください。

## コメント

OKボタンを押した後に送信相手のトーク画面へ送りたいメッセージが送られないため、次回修正します。