### PR TITLE
Add:送られてきた手紙を開いた時のページを実装

### DIFF
--- a/app/controllers/send_letters_controller.rb
+++ b/app/controllers/send_letters_controller.rb
@@ -1,4 +1,6 @@
 class SendLettersController < ApplicationController
+  skip_before_action :login_required, only: %i[show]
+
   require 'net/http'
   require 'uri'
 
@@ -8,6 +10,8 @@ class SendLettersController < ApplicationController
   end
 
   def show
+    @letter = Letter.find_by(token: params[:token])
+    render layout: 'login'
   end
 
   def new

--- a/app/javascript/packs/send_letters/show.js
+++ b/app/javascript/packs/send_letters/show.js
@@ -1,0 +1,35 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const token = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+
+  const LIFF_ID = process.env.LIFF_ID
+  liff.init({
+    liffId: LIFF_ID
+  })
+    .then(() => {
+      if (!liff.isLoggedIn()) {
+        liff.login();
+      }
+    })
+    .then(() => {
+      const idToken = liff.getIDToken();
+      const body = `idToken=${idToken}`
+      const request = new Request('/users', {
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8',
+          'X-CSRF-Token': token
+        },
+        method: 'POST',
+        body: body
+      });
+      fetch(request)
+        .then(response => response.json())
+        .then(data => {
+          data_id = data.id
+      })
+    })
+    .then(() => {
+      if (!liff.isLoggedIn()) {
+        liff.login();
+      }
+    })
+})

--- a/app/views/send_letters/show.html.slim
+++ b/app/views/send_letters/show.html.slim
@@ -1,2 +1,13 @@
-h1 SendLetters#show
-p Find me in app/views/send_letters/show.html.slim
+card.flex.justify-center.items-center
+  div.text-center.leading-5
+    div.shadow-lg.w-auto
+      div.w-full
+        = image_tag('tulip.jpg')
+      div.text-blue-900.main-font.text-1xl.px-4.py-2
+        = @letter.title
+        span.text-blue-900.main-font.text-xs
+          | へ
+      div.text-blue-900.main-font.text-1xl.px-4.py-2
+        = @letter.body
+
+= javascript_pack_tag 'send_letters/show'


### PR DESCRIPTION
## 概要

送られてきた手紙を開いた時のページを実装しました。 6007e7a3a21f2e1496180ec3ef1e5e6ada8a45ac

## 確認方法

1. 送られてきた手紙を開くとアプリへログインし、手紙詳細ページへ遷移すること。
2. 手紙詳細ページには手紙の画像、宛名、本文が表示されていること。
3. ヘッダーのメニューは非表示にし、 `Future Letter`の文字をクリックするとアプリのトップページへ遷移すること。
