### PR TITLE
Fix：URLにidを直打ちしても遷移できないよう修正

### DIFF
--- a/app/controllers/letters_controller.rb
+++ b/app/controllers/letters_controller.rb
@@ -102,7 +102,11 @@ class LettersController < ApplicationController
   def set_letter
     @letter = Letter.find(params[:id])
     user = @letter.user
-    redirect_to(letters_path) unless user == current_user
+    if user != current_user
+      respond_to do |format|
+        format.html { render file: "#{Rails.root}/public/404.html", layout: false, status: :not_found }
+      end
+    end
   end
 
   def letter_params

--- a/app/controllers/letters_controller.rb
+++ b/app/controllers/letters_controller.rb
@@ -101,6 +101,8 @@ class LettersController < ApplicationController
 
   def set_letter
     @letter = Letter.find(params[:id])
+    user = @letter.user
+    redirect_to(letters_path) unless user == current_user
   end
 
   def letter_params

--- a/app/controllers/send_letters_controller.rb
+++ b/app/controllers/send_letters_controller.rb
@@ -11,7 +11,12 @@ class SendLettersController < ApplicationController
 
   def show
     @letter = Letter.find_by(token: params[:token])
-    render layout: 'login'
+    send_letter = SendLetter.find_by(letter_id: @letter.id)
+    if @letter.user || send_letter.destination == current_user
+      render layout: 'login'
+    else
+      redirect_to(top_path) unless user == current_user
+    end
   end
 
   def new

--- a/app/views/letters/_letter.html.slim
+++ b/app/views/letters/_letter.html.slim
@@ -13,4 +13,4 @@
             span.text-blue-900.main-font.text-xs
               | へ
           div.text-blue-900.font.m-5
-            = link_to 'Destroy', letter, method: :delete, data: { confirm: "まだ送信していないお手紙です。\n削除してもよろしいですか?" }, class: "m-3 bg-pink-100 hover:bg-pink-200 rounded-full py-2 px-4"
+            = link_to 'Destroy', letter, method: :delete, data: { confirm: "まだ送信していないお手紙です。\n削除してもよろしいですか?" }, class: "m-1 bg-pink-100 hover:bg-pink-200 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow"

--- a/app/views/letters/index.html.slim
+++ b/app/views/letters/index.html.slim
@@ -1,7 +1,7 @@
 h1.text-blue-900.font.text-2xl.tracking-wider.text-center
   | DRAFT LETTER
 h2.text-center.leading-10.container.mx-auto.text-1xl.text-blue-900.main-font
-  = link_to '新しい手紙を書く', new_letter_path, class: "ml-1 bg-yellow-100 hover:bg-yellow-200 text-blue-900 rounded-full py-2 px-4"
+  = link_to '新しい手紙を書く', new_letter_path, class: "m-1 bg-yellow-100 hover:bg-yellow-200 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow"
 - if @letters.present?
   div.place-items-auto
     = render @letters

--- a/app/views/letters/new.html.slim
+++ b/app/views/letters/new.html.slim
@@ -7,17 +7,21 @@ h1.text-blue-900.font.text-2xl.tracking-wider.text-center
 div.text-blue-900.main-font.text-1xl.tracking-wider.py-3.px-3
   = form_with(model: @letter, id: 'form', local: false) do |f|
     .field
-      = f.label :title
+      .pb-2
+        = f.label :title
       = f.text_field :title, class: "shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
-    .field.py-3
-      = f.label :body
-      = f.text_area :body, class: "resize-none shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline", size: "20x5"
+    .field.py-5
+      .pb-2
+        = f.label :body
+      = f.text_area :body, class: "resize-none shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline", size: "20x8"
     .field.py-3.text-center
-      = f.label :send_date
-      br
-      = f.datetime_field :send_date
+      .pb-2
+        = f.label :send_date
+        br
+      .font.text-1xl
+        = f.datetime_select :send_date, minute_step: 60, default: Time.now + 1.hours, start_year: 2022, end_year: 2023, date_separator: '/', use_month_numbers:true
     .actions.text-center.py-3
-      = f.submit :手紙を送る相手を選ぶ, class: "ml-1 bg-yellow-100 hover:bg-yellow-200 text-blue-900 rounded-full py-2 px-4"
+      = f.submit :手紙を送る相手を選ぶ, class: "m-1 bg-yellow-100 hover:bg-yellow-200 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow"
 div.text-blue-900.font.text-1xl.tracking-wider.text-center
   = link_to 'Back', letters_path
 

--- a/public/404.html
+++ b/public/404.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>The page you were looking for doesn't exist (404)</title>
+  <title>Future Letter ページが見つかりませんでした。 (404)</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <style>
   .rails-default-error-page {
@@ -55,13 +55,10 @@
 </head>
 
 <body class="rails-default-error-page">
-  <!-- This file lives in public/404.html -->
   <div class="dialog">
     <div>
-      <h1>The page you were looking for doesn't exist.</h1>
-      <p>You may have mistyped the address or the page may have moved.</p>
+      <h1>ページが見つかりませんでした。（404）</h1>
     </div>
-    <p>If you are the application owner check the logs for more information.</p>
   </div>
 </body>
 </html>


### PR DESCRIPTION
## 概要
PCで開いた場合、URLにidを直打ちすると他の人の手紙を開けてしまっていた為、URLに直打ちしても開けずに404ページへ遷移するよう設定しました。

- ログインユーザーと手紙のユーザーが一致した場合のみ開けるよう修正 3c0ad2ef46c49ad3ef9a978b033449bf3f954451
- idが一致していない場合、idが存在しない場合に404ページへ遷移するよう修正  7dae5ab8e7182b9e4e3af175ea8f5921f11c31af


## 確認方法

1. 他の人の手紙のidをURLに入力した場合、手紙は開けず404ページへ遷移すること。
2. 存在しないidを入力した場合も、404ページへ遷移すること。

## コメント
404ページは後ほど修正します。