### PR TITLE
Add：友だち登録

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -10,4 +10,8 @@ class HomeController < ApplicationController
   def description; end
 
   def mypage; end
+
+  def friend
+    render layout: 'login'
+  end
 end

--- a/app/javascript/packs/letters/invite.js
+++ b/app/javascript/packs/letters/invite.js
@@ -48,7 +48,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 data_id = data.id
               })
               .then(() => {
-                liff.closeWindow();
+                window.location = '/friend'
               })
               .catch((err) => {
                 console.log(err.code, err.message);

--- a/app/views/home/description.html.slim
+++ b/app/views/home/description.html.slim
@@ -5,7 +5,11 @@ h1.text-blue-900.font.text-2xl.tracking-wider.text-center.py-6
     | 1. 手紙を書き、送信日時を設定する。
   br
   p
-    | 2. 送信したい相手をLINEの友達から選ぶ。
+    | 2. 送信したい相手を
+    span.text-blue-900.font.text-1xl.tracking-wider.text-center
+      | LINE
+      span.text-blue-900.main-font.text-1xl.tracking-wider.text-center
+        | の友達から選ぶ。
   br
   p
     | 3. 相手に宛名を確認してもらい、
@@ -20,6 +24,10 @@ h1.text-blue-900.font.text-2xl.tracking-wider.text-center.py-6
   p
     | ※ サプライズで手紙を届けるためには
   p
-    | 送信相手の方にもFUTURE LETTERへ
+    | 送信相手の方にも
+    span.text-blue-900.font.text-1xl.tracking-wider.text-center
+      | FUTURE LETTER
+      span.text-blue-900.main-font.text-1xl.tracking-wider.text-center
+        | へ
   p
     | 友達登録してもらう必要があります。

--- a/app/views/home/friend.html.slim
+++ b/app/views/home/friend.html.slim
@@ -1,0 +1,43 @@
+div.pt-2
+  card.flex.justify-center.items-center
+      div.text-center.leading-5
+        div.shadow-lg.w-auto
+          div.w-full
+            = image_tag('icon.jpg')
+            .text-blue-900.main-font.text-1xl.tracking-wider.text-center.px-4.py-2
+              p
+                | 大切なひと、未来の自分へ
+              p
+                | 今の気持ちを手紙にして送りませんか？
+
+h1.text-blue-900.font.text-2xl.tracking-wider.text-center.py-6
+  | PLEASE ADD ME
+  br
+  | AS A LINE FRIEND !
+
+.text-blue-900.main-font.text-1xl.tracking-wider.text-center
+  p
+    | お手紙を受け取るには
+  br
+.text-blue-900.font.text-1xl.tracking-wider.text-center
+  p
+    | FUTURE LETTER
+    span.text-blue-900.main-font.text-1xl.tracking-wider.text-center
+      | を
+  br
+.text-blue-900.main-font.text-1xl.tracking-wider.text-center
+  p
+    | 友だち登録する必要があります。
+  br
+  p
+    | 下のボタンからぜひ登録してください！
+
+div.flex.justify-center.text-5xl.py-6
+  div class="line-it-button" data-lang="ja" data-type="friend" data-env="REAL" data-lineId="@727jqlfj" style="display: none;"
+  script src="https://www.line-website.com/social-plugins/js/thirdparty/loader.min.js" async="async" defer="defer"
+
+.text-blue-900.main-font.text-xs.tracking-wider.text-center
+  p
+    | ※ アプリの操作自体は友だち登録をしなくても行えますが、
+  p
+    | 友だち登録をしないとお手紙は受け取れません。

--- a/app/views/home/top.html.slim
+++ b/app/views/home/top.html.slim
@@ -29,7 +29,11 @@ h1.text-blue-900.font.text-2xl.tracking-wider.text-center.py-6
     | 1. 手紙を書き、送信日時を設定する。
   br
   p
-    | 2. 送信したい相手をLINEの友達から選ぶ。
+    | 2. 送信したい相手を
+    span.text-blue-900.font.text-1xl.tracking-wider.text-center
+      | LINE
+      span.text-blue-900.main-font.text-1xl.tracking-wider.text-center
+        | の友達から選ぶ。
   br
   p
     | 3. 相手に宛名を確認してもらい、
@@ -44,7 +48,11 @@ h1.text-blue-900.font.text-2xl.tracking-wider.text-center.py-6
   p
     | ※ サプライズで手紙を届けるためには
   p
-    | 送信相手の方にもFUTURE LETTERへ
+    | 送信相手の方にも
+    span.text-blue-900.font.text-1xl.tracking-wider.text-center
+      | FUTURE LETTER
+      span.text-blue-900.main-font.text-1xl.tracking-wider.text-center
+        | へ
   p
     | 友達登録してもらう必要があります。
 

--- a/app/views/letters/edit.html.slim
+++ b/app/views/letters/edit.html.slim
@@ -17,11 +17,20 @@ div.text-blue-900.main-font.text-1xl.tracking-wider.py-3.px-3
       br
       = f.file_field :image
     .field.py-3.text-center
-      = f.label :send_date
-      br
-      = f.datetime_field :send_date
+      .pb-2
+        = f.label :send_date
+        br
+      .font.text-1xl
+        = f.datetime_select :send_date, minute_step: 60, default: Time.now + 1.hours, start_year: 2022, end_year: 2023, date_separator: '/', use_month_numbers: true
     .actions.text-center.py-3
       = f.submit :手紙を送る相手を選ぶ, class: "ml-1 bg-yellow-100 hover:bg-yellow-200 text-blue-900 rounded-full py-2 px-4"
+
+.text-blue-900.main-font.text-xs.tracking-wider.text-center.pb-3
+  p
+    | ※ 画像を選択した場合、動作が遅い場合があります。
+  p
+    | しばらくお待ちください。
+
 div.text-blue-900.font.text-1xl.tracking-wider.text-center
   = link_to 'Back', letters_path
 

--- a/app/views/letters/invite.html.slim
+++ b/app/views/letters/invite.html.slim
@@ -1,12 +1,14 @@
 = javascript_pack_tag 'letters/invite'
 
-div.text-blue-900.main-font.text-1xl.tracking-wider.text-center
+.text-blue-900.main-font.text-1xl.tracking-wider.text-center
   p
     | サプライズでお手紙を送りたいです。
   p
     | 表示されているお名前が正しければ
-  p
-    | 「OK」を押してください。
+  p.text-blue-900.font.text-1xl.tracking-wider.text-center
+    | 「OK」
+    span.text-blue-900.main-font.text-1xl.tracking-wider.text-center
+      | を押してください。
 br
 div.text-center.leading-5
   div.shadow-lg.w-auto
@@ -17,4 +19,4 @@ div.text-center.leading-5
       span.text-blue-900.main-font.text-xs
         | へ
 div.text-blue-900.m-5.font.text-center
-  = link_to "OK", reserve_letter_path(@letter.id), id: 'ok', remote: true, data: { confirm: "FUTURE LETTER 公式アカウントより\n後日お手紙が届きます。よろしいですか?" }, class: "m-1 bg-pink-100 hover:bg-pink-200 border border-blue-900 rounded-full shadow py-2 px-4"
+  = link_to "OK", reserve_letter_path(@letter.id), id: 'ok', remote: true, data: { confirm: "FUTURE LETTER 公式アカウントをより\n後日お手紙が届きます。よろしいですか?" }, class: "m-1 bg-pink-100 hover:bg-pink-200 border border-blue-900 rounded-full shadow py-2 px-4"

--- a/app/views/letters/invite.html.slim
+++ b/app/views/letters/invite.html.slim
@@ -19,4 +19,4 @@ div.text-center.leading-5
       span.text-blue-900.main-font.text-xs
         | へ
 div.text-blue-900.m-5.font.text-center
-  = link_to "OK", reserve_letter_path(@letter.id), id: 'ok', remote: true, data: { confirm: "FUTURE LETTER 公式アカウントをより\n後日お手紙が届きます。よろしいですか?" }, class: "m-1 bg-pink-100 hover:bg-pink-200 border border-blue-900 rounded-full shadow py-2 px-4"
+  = link_to "OK", reserve_letter_path(@letter.id), id: 'ok', remote: true, data: { confirm: "FUTURE LETTER 公式アカウントより\n後日お手紙が届きます。よろしいですか?" }, class: "m-1 bg-pink-100 hover:bg-pink-200 border border-blue-900 rounded-full shadow py-2 px-4"

--- a/app/views/letters/new.html.slim
+++ b/app/views/letters/new.html.slim
@@ -23,9 +23,16 @@ div.text-blue-900.main-font.text-1xl.tracking-wider.py-3.px-3
         = f.label :send_date
         br
       .font.text-1xl
-        = f.datetime_select :send_date, minute_step: 60, default: Time.now + 1.hours, start_year: 2022, end_year: 2023, date_separator: '/', use_month_numbers:true
+        = f.datetime_select :send_date, minute_step: 60, default: Time.now + 1.hours, start_year: 2022, end_year: 2023, date_separator: '/', use_month_numbers: true
     .actions.text-center.py-3
       = f.submit :手紙を送る相手を選ぶ, class: "m-1 bg-yellow-100 hover:bg-yellow-200 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow"
+
+.text-blue-900.main-font.text-xs.tracking-wider.text-center.pb-3
+  p
+    | ※ 画像を選択した場合、動作が遅い場合があります。
+  p
+    | しばらくお待ちください。
+
 div.text-blue-900.font.text-1xl.tracking-wider.text-center
   = link_to 'Back', letters_path
 

--- a/app/views/send_letters/show.html.slim
+++ b/app/views/send_letters/show.html.slim
@@ -2,7 +2,12 @@ card.flex.justify-center.items-center
   div.text-center.leading-5
     div.shadow-lg.w-auto
       div.w-full
-        = image_tag('tulip.jpg')
+        - if @letter.image.present?
+          = link_to edit_letter_path(@letter) do
+            = image_tag @letter.image.to_s
+        - else
+          = link_to image_tag('default.jpg'), edit_letter_path(@letter)
+
       div.text-blue-900.main-font.text-1xl.px-4.py-2
         = @letter.title
         span.text-blue-900.main-font.text-xs

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,5 +18,6 @@ Rails.application.routes.draw do
   get 'description', to: 'home#description'
   get 'top', to: 'home#top'
   get 'mypage', to: 'home#mypage'
+  get 'friend', to: 'home#friend'
   post 'callback', to: 'linebot#callback'
 end

--- a/lib/tasks/check_date.rake
+++ b/lib/tasks/check_date.rake
@@ -37,7 +37,7 @@ namespace :check_date do
               "thumbnailImageUrl": "https://cdn.pixabay.com/photo/2016/09/10/17/17/letters-1659715_1280.jpg",
               "type": "buttons",
               "title": "FUTURE LETTER",
-              "text": "お手紙を書きました！",
+              "text": "お手紙が届いています！",
               "actions": [
                   {
                     "type": "uri",
@@ -96,7 +96,7 @@ namespace :check_date do
                 "thumbnailImageUrl": "https://cdn.pixabay.com/photo/2016/09/10/17/17/letters-1659715_1280.jpg",
                 "type": "buttons",
                 "title": "FUTURE LETTER",
-                "text": "設定した日時が近くなりました。\nお手紙を送る相手を選択しましょう。",
+                "text": "設定した送信日時が近くなりました。\nお手紙を送る相手を選択しましょう。",
                 "actions": [
                     {
                       "type": "uri",


### PR DESCRIPTION
## 概要
友だち登録ページを追加しました。

- `friend`アクションを追加、友だち登録ページを作成 ada334b68d3f7057a522e509d804e2ea515c105e d1fe51261537a21c055307f19dc5fd75f3acb0b5
- CSS、トーク画面に送信されるメッセージの修正 a703ce0af1d1d4cb96ae8af305a9836ec24bc41b b059f7e9231fb234a15a4b21498d92980ecffe70

## 確認方法

1. 宛名確認メッセージのOKボタンを押すと、友だち登録ページへ遷移すること。
2. 友だち登録ページ内の友だち登録ボタンから友だち登録が出来ること。

## コメント

今後、友だち登録している場合はページを表示させないよう修正します。