### PR TITLE
Fix：環境変数の設定

### DIFF
--- a/app/javascript/packs/letters/new.js
+++ b/app/javascript/packs/letters/new.js
@@ -32,8 +32,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const postFormElm = document.querySelector('#form')
   postFormElm.addEventListener('ajax:success', (e) => {
-    // liff_id部分の埋め込み方法を考える。
-    const redirect_url = `https://liff.line.me/liff_id/open?token=${e.detail[0].token}`
+    const liff_id = process.env.LIFF_ID
+    const redirect_url = `https://liff.line.me/${liff_id}/open?token=${e.detail[0].token}`
     liff.shareTargetPicker([
       message = {
         "type": "template",
@@ -41,7 +41,7 @@ document.addEventListener('DOMContentLoaded', () => {
         "template": {
           "thumbnailImageUrl": "https://cdn.pixabay.com/photo/2016/10/16/21/30/newspaper-1746350_1280.jpg",
             "type": "buttons",
-            "title": "お手紙",
+            "title": "FUTURE LETTER",
             "text": "お手紙を送りたいです！\n宛名を確認してください。",
             "actions": [
                 {

--- a/app/views/home/description.html.slim
+++ b/app/views/home/description.html.slim
@@ -31,12 +31,12 @@ h1.text-blue-900.font.text-2xl.tracking-wider.text-center.py-6
         span.main-font
           | を
     p
-      | 友達登録してもらう必要があります。
+      | 友だち追加してもらう必要があります。
 
 .flex.justify-center.pt-6
   .text-blue-900.main-font.text-1xl.tracking-wider.text-center
     p
-      | 友だち登録はこちら
+      | 友だち追加はこちら
 .flex.justify-center.pt-1
   div class="line-it-button" data-lang="ja" data-type="friend" data-env="REAL" data-lineId="@727jqlfj" style="display: none;"
   script src="https://www.line-website.com/social-plugins/js/thirdparty/loader.min.js" async="async" defer="defer"

--- a/app/views/home/friend.html.slim
+++ b/app/views/home/friend.html.slim
@@ -1,43 +1,40 @@
 div.pt-2
-  card.flex.justify-center.items-center
-      div.text-center.leading-5
-        div.shadow-lg.w-auto
-          div.w-full
-            = image_tag('icon.jpg')
-            .text-blue-900.main-font.text-1xl.tracking-wider.text-center.px-4.py-2
-              p
-                | 大切なひと、未来の自分へ
-              p
-                | 今の気持ちを手紙にして送りませんか？
+  card.justify-center.items-center.m-auto.w-1/2
+    div.text-center.leading-5
+      div.shadow-lg.w-auto
+        div.w-full
+          = image_tag('icon.jpg')
 
 h1.text-blue-900.font.text-2xl.tracking-wider.text-center.py-6
   | PLEASE ADD ME
   br
   | AS A LINE FRIEND !
-
 .text-blue-900.main-font.text-1xl.tracking-wider.text-center
   p
-    | お手紙を受け取るには
-  br
-.text-blue-900.font.text-1xl.tracking-wider.text-center
+    | 宛名のご確認ありがとうございました !
+    br
+  p
+    | このお手紙を受け取るには
+.text-blue-900.font.text-1xl.tracking-wider.text-center.font-black.underline
   p
     | FUTURE LETTER
-    span.text-blue-900.main-font.text-1xl.tracking-wider.text-center
+    span.main-font
       | を
-  br
+      span.text-green-600
+        | 友だち追加
 .text-blue-900.main-font.text-1xl.tracking-wider.text-center
   p
-    | 友だち登録する必要があります。
+    | する必要があります。
   br
   p
-    | 下のボタンからぜひ登録してください！
+    | 下のボタンからぜひ追加してください！
 
-div.flex.justify-center.text-5xl.py-6
-  div class="line-it-button" data-lang="ja" data-type="friend" data-env="REAL" data-lineId="@727jqlfj" style="display: none;"
-  script src="https://www.line-website.com/social-plugins/js/thirdparty/loader.min.js" async="async" defer="defer"
+  .flex.justify-center.py-6
+    div class="line-it-button" data-lang="ja" data-type="friend" data-env="REAL" data-lineId="@727jqlfj" style="display: none;"
+    script src="https://www.line-website.com/social-plugins/js/thirdparty/loader.min.js" async="async" defer="defer"
 
 .text-blue-900.main-font.text-xs.tracking-wider.text-center
   p
-    | ※ アプリの操作自体は友だち登録をしなくても行えますが、
+    | ※ アプリの操作自体は友だち追加をしなくても行えますが、
   p
-    | 友だち登録をしないとお手紙は受け取れません。
+    | 友だち追加をしないとお手紙は受け取れません。

--- a/app/views/home/top.html.slim
+++ b/app/views/home/top.html.slim
@@ -4,11 +4,11 @@ div.pt-6
         div.shadow-lg.w-auto
           div.w-full
             = image_tag('icon.jpg')
-            .text-blue-900.main-font.text-1xl.tracking-wider.text-center.px-4.py-2
-              p
-                | 大切なひと、未来の自分へ
-              p
-                | 今の気持ちを手紙にして送りませんか？
+          .text-blue-900.main-font.text-1xl.tracking-wider.text-center.px-4.py-2
+            p
+              | 大切なひと、未来の自分へ
+            p
+              | 今の気持ちを手紙にして送りませんか？
 
 h1.text-blue-900.font.text-2xl.tracking-wider.text-center.py-6
   | WHEN TO USE
@@ -84,12 +84,12 @@ h1.text-blue-900.font.text-2xl.tracking-wider.text-center.py-6
         span.main-font
           | を
     p
-      | 友達登録してもらう必要があります。
+      | 友だち追加してもらう必要があります。
 
 .flex.justify-center.pt-6
   .text-blue-900.main-font.text-1xl.tracking-wider.text-center
     p
-      | 友だち登録はこちら
+      | 友だち追加はこちら
 .flex.justify-center.pt-1
   div class="line-it-button" data-lang="ja" data-type="friend" data-env="REAL" data-lineId="@727jqlfj" style="display: none;"
   script src="https://www.line-website.com/social-plugins/js/thirdparty/loader.min.js" async="async" defer="defer"

--- a/app/views/letters/invite.html.slim
+++ b/app/views/letters/invite.html.slim
@@ -9,14 +9,19 @@
     | 「OK」
     span.text-blue-900.main-font.text-1xl.tracking-wider.text-center
       | を押してください。
-br
-div.text-center.leading-5
-  div.shadow-lg.w-auto
-    div.w-full
-      = image_tag('tulip.jpg')
-    div.text-blue-900.main-font.text-1xl.px-4.py-2
-      = @letter.title
-      span.text-blue-900.main-font.text-xs
-        | へ
+      br
+
+card.flex.justify-center.items-center
+  div.text-center.leading-5
+    div.shadow-lg.w-auto
+      div.w-full
+        - if @letter.image.present?
+          = image_tag @letter.image.to_s
+        - else
+          = image_tag('default.jpg')
+      div.text-blue-900.main-font.text-1xl.px-4.py-2
+        = @letter.title
+        span.main-font.text-xs
+          | へ
 div.text-blue-900.m-5.font.text-center
   = link_to "OK", reserve_letter_path(@letter.id), id: 'ok', remote: true, data: { confirm: "FUTURE LETTER 公式アカウントより\n後日お手紙が届きます。よろしいですか?" }, class: "m-1 bg-pink-100 hover:bg-pink-200 border border-blue-900 rounded-full shadow py-2 px-4"

--- a/app/views/letters/new.html.slim
+++ b/app/views/letters/new.html.slim
@@ -32,6 +32,11 @@ div.text-blue-900.main-font.text-1xl.tracking-wider.py-3.px-3
     | ※ 画像を選択した場合、動作が遅い場合があります。
   p
     | しばらくお待ちください。
+    br
+  p
+    | ※ 自分宛に送信する場合は、
+  p
+    | 事前に自分専用のトークルームを作成して送信してください。
 
 div.text-blue-900.font.text-1xl.tracking-wider.text-center
   = link_to 'Back', letters_path

--- a/app/views/send_letters/show.html.slim
+++ b/app/views/send_letters/show.html.slim
@@ -15,4 +15,7 @@ card.flex.justify-center.items-center
       div.text-blue-900.main-font.text-1xl.px-4.py-2
         = @letter.body
 
+div.text-blue-900.font.text-1xl.tracking-wider.text-center
+  = link_to 'Back', send_letters_path
+
 = javascript_pack_tag 'send_letters/show'

--- a/app/views/send_letters/show.html.slim
+++ b/app/views/send_letters/show.html.slim
@@ -3,10 +3,9 @@ card.flex.justify-center.items-center
     div.shadow-lg.w-auto
       div.w-full
         - if @letter.image.present?
-          = link_to edit_letter_path(@letter) do
-            = image_tag @letter.image.to_s
+          = image_tag @letter.image.to_s
         - else
-          = link_to image_tag('default.jpg'), edit_letter_path(@letter)
+          = image_tag('default.jpg')
 
       div.text-blue-900.main-font.text-1xl.px-4.py-2
         = @letter.title

--- a/app/views/shared/_footer.html.slim
+++ b/app/views/shared/_footer.html.slim
@@ -1,7 +1,7 @@
 footer.py-6
-  .copyright
-    p.font.text-center.text-blue-900.text-xs
+  .copyright.font.text-center.text-blue-900
+    p.text-xs
       | App photo and illustration by
       = link_to 'icons8', 'https://icons8.com/'
-    p.font.text-center.text-blue-900
+    p
       | Copyright © 2022  FUTURE LETTER

--- a/app/views/shared/_footer_login.html.slim
+++ b/app/views/shared/_footer_login.html.slim
@@ -1,7 +1,7 @@
 footer.py-6
-  .copyright
-    p.font.text-center.text-blue-900.text-xs
+  .copyright.font.text-center.text-blue-900
+    p.text-xs
       | App photo and illustration by
       = link_to 'icons8', 'https://icons8.com/'
-    p.font.text-center.text-blue-900
+    p
       | Copyright © 2022  FUTURE LETTER

--- a/app/views/shared/_header_login.html.slim
+++ b/app/views/shared/_header_login.html.slim
@@ -1,4 +1,5 @@
 header
   div.text-blue-900.font.text-2xl.tracking-wider.text-center.py-4
     = link_to top_path do
-      p FUTURE LETTER
+      p
+        | FUTURE LETTER

--- a/lib/tasks/check_date.rake
+++ b/lib/tasks/check_date.rake
@@ -2,6 +2,7 @@ namespace :check_date do
   desc "push_line"
 
   task push_line: :environment do
+    liff_id = ENV['LIFF_ID']
     letters = Letter.where('send_date <= ? and send_date > ?', Time.now, Time.now - 1.hours)
     letters.each do |letter|
       if SendLetter.find_by(letter_id: letter.id).present?
@@ -17,8 +18,7 @@ namespace :check_date do
                   {
                     "type": "uri",
                     "label": "送ったお手紙を確認する",
-                    # liff_id部分の埋め込み方法を考える。
-                    "uri": "https://liff.line.me/liff_id/send_letters/#{letter.token}"
+                    "uri": "https://liff.line.me/#{liff_id}/send_letters/#{letter.token}"
                   }
               ]
           }
@@ -42,8 +42,7 @@ namespace :check_date do
                   {
                     "type": "uri",
                     "label": "お手紙を読む",
-                    # liff_id部分の埋め込み方法を考える。
-                    "uri": "https://liff.line.me/liff_id/send_letters/#{letter.token}"
+                    "uri": "https://liff.line.me/#{liff_id}/send_letters/#{letter.token}"
                   }
               ]
           }
@@ -69,8 +68,7 @@ namespace :check_date do
                   {
                     "type": "uri",
                     "label": "お手紙を確認する",
-                    # liff_id部分の埋め込み方法を考える。
-                    "uri": "https://liff.line.me/liff_id/letters/#{letter.id}/edit"
+                    "uri": "https://liff.line.me/#{liff_id}/letters/#{letter.id}/edit"
                   }
               ]
           }
@@ -86,6 +84,7 @@ namespace :check_date do
   end
 
   task push_remind: :environment do
+    liff_id = ENV['LIFF_ID']
     letters = Letter.where('send_date <= ? and send_date > ?', Time.now.since(3.days), Time.now)
     letters.each do |letter|
       if SendLetter.where(letter_id: letter.id).blank?
@@ -101,8 +100,7 @@ namespace :check_date do
                     {
                       "type": "uri",
                       "label": "お手紙を確認する",
-                      # liff_id部分の埋め込み方法を考える。
-                      "uri": "https://liff.line.me/liff_id/letters/#{letter.id}/edit"
+                      "uri": "https://liff.line.me/#{liff_id}/letters/#{letter.id}/edit"
                     }
                 ]
             }


### PR DESCRIPTION
## 概要
`LIFF_ID`に環境変数を設定しました。
また、送信された手紙から編集ページへ遷移できてしまっていたため、遷移しないよう修正しました。他、CSSや送信されるメッセージの修正を行いました。

- `new.js`、 `check_date.rake`に使用する `LIFF ID`に環境変数を設定  93eea9bd9c22bddd6feb28ed87a7a3c5abb24fee
- CSS、メッセージの修正 dd865bf82d094ff5a5e8152156ca58a58b516e40
- 送信した手紙は編集出来ないよう修正 ee50e6bf59c76f24c23d4126954be0fdbcfba9e7

## 確認方法

1. 手紙の作成、schedulerによる定期実行が問題なく実行されることをご確認ください。
2. 送信された手紙、送られてきた手紙を開いた時、画像をクリックしてもページ遷移されないことをご確認ください。