### PR TITLE
Add：image_cacheを追加、CSSの追加

### DIFF
--- a/app/controllers/letters_controller.rb
+++ b/app/controllers/letters_controller.rb
@@ -6,7 +6,7 @@ class LettersController < ApplicationController
   require 'uri'
 
   def index
-    @letters = Letter.where(user_id: current_user.id).includes(:user).order("created_at DESC")
+    @letters = Letter.where(user_id: current_user.id).includes(:user).order("send_date ASC")
   end
 
   def show; end
@@ -73,7 +73,9 @@ class LettersController < ApplicationController
     p response
   end
 
-  def edit; end
+  def edit
+    @letter.image.cache! if @letter.image.present?
+  end
 
   def update
     if @letter.update(letter_params)
@@ -110,6 +112,6 @@ class LettersController < ApplicationController
   end
 
   def letter_params
-    params.require(:letter).permit(:title, :body, :image, :user_id, :template_id, :token, :send_date)
+    params.require(:letter).permit(:title, :body, :image, :image_cache, :user_id, :template_id, :token, :send_date)
   end
 end

--- a/app/views/home/mypage.html.slim
+++ b/app/views/home/mypage.html.slim
@@ -10,7 +10,7 @@ div.text-blue-900.main-font.text-1xl.tracking-wider.text-center.font-black
   .flex.justify-center
     .w-6
       = image_tag('mail.jpg')
-    = link_to '下書き', letters_path
+    = link_to '下書き一覧', letters_path
   br
   .flex.justify-center
     .w-6

--- a/app/views/letters/edit.html.slim
+++ b/app/views/letters/edit.html.slim
@@ -1,35 +1,51 @@
 h1.text-blue-900.font.text-2xl.tracking-wider.text-center.py-6
   | EDIT LETTER
 
-#error_explanation
-  = render 'shared/err_msg', letter: @letter
-
-div.text-blue-900.main-font.text-1xl.tracking-wider.py-3.px-3
+div.text-blue-900.main-font.text-1xl.tracking-wider.px-3
   = form_with(model: @letter, id: 'form', local: false) do |f|
-    .field
-      = f.label :title
-      = f.text_field :title, class: "shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
-    .field.py-3
-      = f.label :body
-      = f.text_area :body, class: "resize-none shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline", size: "20x5"
-    .field.py-3.text-center
-      = f.label :image
-      br
-      = f.file_field :image
-    .field.py-3.text-center
+    .field.pb-3.text-center.font-black
       .pb-2
+        = f.label :image
+      .justify-center
+        = f.file_field :image
+        = f.hidden_field :image_cache
+      - if @letter.image.present?
+        .pt-2
+          = image_tag(@letter.image.url)
+    .field.py-3.text-center
+      .pb-2.font-black
+        = f.label :title
+      .flex.items-center
+        = f.text_field :title, class: "shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline", placeholder: "〇〇〇"
+        span.pl-3.font-black
+          | へ
+    .field.py-3.text-center
+      .pb-2.font-black
+        = f.label :body
+      = f.text_area :body, class: "resize-none shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline", size: "20x8", placeholder: "手紙を書いたよ！いつもありがとう。"
+    .field.py-3.text-center
+      .pb-2.font-black
         = f.label :send_date
         br
       .font.text-1xl
         = f.datetime_select :send_date, minute_step: 60, default: Time.now + 1.hours, start_year: 2022, end_year: 2023, date_separator: '/', use_month_numbers: true
-    .actions.text-center.py-3
-      = f.submit :手紙を送る相手を選ぶ, class: "ml-1 bg-yellow-100 hover:bg-yellow-200 text-blue-900 rounded-full py-2 px-4"
 
-.text-blue-900.main-font.text-xs.tracking-wider.text-center.pb-3
+    #error_explanation
+      = render 'shared/err_msg', letter: @letter
+
+    .actions.text-center.py-3
+      = f.submit :手紙を送る相手を選ぶ, class: "m-1 bg-yellow-100 hover:bg-yellow-200 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow"
+
+.text-blue-900.main-font.text-xs.tracking-wider.text-center.pt-3.pb-6
   p
     | ※ 画像を選択した場合、動作が遅い場合があります。
   p
     | しばらくお待ちください。
+  br
+  p
+    | ※ 自分宛に送信する場合は、
+  p
+    | 事前に自分専用のトークルームを作成して送信してください。
 
 div.text-blue-900.font.text-1xl.tracking-wider.text-center
   = link_to 'Back', letters_path

--- a/app/views/letters/index.html.slim
+++ b/app/views/letters/index.html.slim
@@ -1,7 +1,9 @@
-h1.text-blue-900.font.text-2xl.tracking-wider.text-center.py-6
-  | DRAFT LETTER
-h2.text-center.leading-10.container.mx-auto.text-1xl.text-blue-900.main-font.pb-6
+h1.text-center.leading-10.container.mx-auto.text-1xl.text-blue-900.main-font.py-6
   = link_to '新しい手紙を書く', new_letter_path, class: "m-1 bg-yellow-100 hover:bg-yellow-200 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow"
+
+h1.text-blue-900.font.text-2xl.tracking-wider.text-center.pb-6
+  | DRAFT LETTER
+
 - if @letters.present?
   div.place-items-auto
     = render @letters

--- a/app/views/letters/new.html.slim
+++ b/app/views/letters/new.html.slim
@@ -3,7 +3,16 @@ h1.text-blue-900.font.text-2xl.tracking-wider.text-center.py-6
 
 div.text-blue-900.main-font.text-1xl.tracking-wider.px-3
   = form_with(model: @letter, id: 'form', local: false) do |f|
-    .field.py-2.text-center
+    .field.pb-3.text-center.font-black
+      .pb-2
+        = f.label :image
+      .justify-center
+        = f.file_field :image
+        = f.hidden_field :image_cache
+      - if @letter.image.present?
+        .pt-2
+          = image_tag(@letter.image.url)
+    .field.py-3.text-center
       .pb-2.font-black
         = f.label :title
       .flex.items-center
@@ -14,10 +23,6 @@ div.text-blue-900.main-font.text-1xl.tracking-wider.px-3
       .pb-2.font-black
         = f.label :body
       = f.text_area :body, class: "resize-none shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline", size: "20x8", placeholder: "手紙を書いたよ！いつもありがとう。"
-    .field.py-2.text-center.font-black
-      = f.label :image
-      br
-      = f.file_field :image
     .field.py-3.text-center
       .pb-2.font-black
         = f.label :send_date

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -25,7 +25,7 @@ header
       p.text-center.text-blue-900.font.text-xs
         | MY PAGE
     li.menu.image.container.shadow-lg.mx-auto.tracking-wider.w-1/3
-      = link_to image_tag('post.jpg'), new_letter_path
+      = link_to image_tag('post.jpg'), letters_path
       p.text-center.text-blue-900.font.text-xs
         | NEW LETTER
     li.menu.image.container.shadow-lg.mx-auto.tracking-wider.w-1/3


### PR DESCRIPTION
## 概要

- image_cacheを追加 73294d6c90f28eeb6edff936bd431648bb90790d
- CSS、文章の修正 b38aaa42f3b3f2fe4617a26b9b5b18774499edb2

## 確認方法
- バリデーションに引っかかった時、手紙編集画面を開いた時、設定した画像が表示されていること。