### PR TITLE
Fix：schedulerで送信された手紙を開いた時のログイン

### DIFF
--- a/app/controllers/letters_controller.rb
+++ b/app/controllers/letters_controller.rb
@@ -1,5 +1,5 @@
 class LettersController < ApplicationController
-  skip_before_action :login_required, only: %i[open]
+  skip_before_action :login_required, only: %i[open confirm]
   before_action :set_letter, only: %i[edit update destroy]
 
   require 'net/http'
@@ -8,8 +8,6 @@ class LettersController < ApplicationController
   def index
     @letters = Letter.where(user_id: current_user.id).includes(:user).order("send_date ASC")
   end
-
-  def show; end
 
   def invite
     @user = User.find(session[:user_id])
@@ -96,6 +94,10 @@ class LettersController < ApplicationController
   end
 
   def open
+    render layout: 'login'
+  end
+
+  def confirm
     render layout: 'login'
   end
 

--- a/app/controllers/send_letters_controller.rb
+++ b/app/controllers/send_letters_controller.rb
@@ -1,8 +1,12 @@
 class SendLettersController < ApplicationController
-  skip_before_action :login_required, only: %i[show]
+  skip_before_action :login_required, only: %i[show login]
 
   require 'net/http'
   require 'uri'
+
+  def login
+    render layout: 'login'
+  end
 
   def index
     user = current_user
@@ -19,8 +23,7 @@ class SendLettersController < ApplicationController
     end
   end
 
-  def new
-  end
+  def new;  end
 
   def create
     idToken = params[:idToken]
@@ -32,12 +35,6 @@ class SendLettersController < ApplicationController
     letter = Letter.find_by(token: params[:letterToken])
     send_letter = SendLetter.new(destination_id: destination_id ,letter_id: letter.id)
     send_letter.save! if SendLetter.find_by(letter_id: letter.id) == nil
-  end
-
-  def edit
-  end
-
-  def update
   end
 
   def destroy

--- a/app/controllers/send_letters_controller.rb
+++ b/app/controllers/send_letters_controller.rb
@@ -1,5 +1,5 @@
 class SendLettersController < ApplicationController
-  skip_before_action :login_required, only: %i[show login]
+  skip_before_action :login_required, only: %i[login]
 
   require 'net/http'
   require 'uri'

--- a/app/controllers/send_letters_controller.rb
+++ b/app/controllers/send_letters_controller.rb
@@ -36,12 +36,4 @@ class SendLettersController < ApplicationController
     send_letter = SendLetter.new(destination_id: destination_id ,letter_id: letter.id)
     send_letter.save! if SendLetter.find_by(letter_id: letter.id) == nil
   end
-
-  def destroy
-    @letter.destroy!
-    respond_to do |format|
-      format.html { redirect_to send_letters_url }
-      format.json { head :no_content }
-    end
-  end
 end

--- a/app/javascript/packs/letters/confirm.js
+++ b/app/javascript/packs/letters/confirm.js
@@ -1,0 +1,33 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const token = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+
+  const LIFF_ID = process.env.LIFF_ID
+  liff.init({
+    liffId: LIFF_ID
+  })
+    .then(() => {
+      if (!liff.isLoggedIn()) {
+        liff.login();
+      }
+    })
+    .then(() => {
+      const idToken = liff.getIDToken();
+      const body = `idToken=${idToken}`
+      const request = new Request('/users', {
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8',
+          'X-CSRF-Token': token
+        },
+        method: 'POST',
+        body: body
+      });
+
+      fetch(request)
+        .then(() => {
+          const params = new URLSearchParams(window.location.search);
+          const id = params.get('id')
+          const redirect_url = `/letters/${id}/edit`
+          window.location = redirect_url
+        })
+    })
+})

--- a/app/javascript/packs/send_letters/login.js
+++ b/app/javascript/packs/send_letters/login.js
@@ -1,0 +1,33 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const token = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+
+  const LIFF_ID = process.env.LIFF_ID
+  liff.init({
+    liffId: LIFF_ID
+  })
+    .then(() => {
+      if (!liff.isLoggedIn()) {
+        liff.login();
+      }
+    })
+    .then(() => {
+      const idToken = liff.getIDToken();
+      const body = `idToken=${idToken}`
+      const request = new Request('/users', {
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8',
+          'X-CSRF-Token': token
+        },
+        method: 'POST',
+        body: body
+      });
+
+      fetch(request)
+        .then(() => {
+          const params = new URLSearchParams(window.location.search);
+          const letter_token = params.get('token')
+          const redirect_url = `/send_letters/${letter_token}`
+          window.location = redirect_url
+        })
+    })
+})

--- a/app/views/letters/confirm.html.slim
+++ b/app/views/letters/confirm.html.slim
@@ -1,0 +1,4 @@
+p.text-blue-900.main-font.text-1xl.container.mx-auto.text-center
+  | 処理中です...お待ちください...
+
+= javascript_pack_tag 'letters/confirm'

--- a/app/views/letters/invite.html.slim
+++ b/app/views/letters/invite.html.slim
@@ -11,7 +11,7 @@
       | を押してください。
       br
 
-card.flex.justify-center.items-center
+card.flex.justify-center.items-center.py-3
   div.text-center.leading-5
     div.shadow-lg.w-auto
       div.w-full
@@ -23,5 +23,6 @@ card.flex.justify-center.items-center
         = @letter.title
         span.main-font.text-xs
           | へ
-div.text-blue-900.m-5.font.text-center
+
+div.text-blue-900.font.text-center
   = link_to "OK", reserve_letter_path(@letter.id), id: 'ok', remote: true, data: { confirm: "FUTURE LETTER 公式アカウントより\n後日お手紙が届きます。よろしいですか?" }, class: "m-1 bg-pink-100 hover:bg-pink-200 border border-blue-900 rounded-full shadow py-2 px-4"

--- a/app/views/letters/open.html.slim
+++ b/app/views/letters/open.html.slim
@@ -1,1 +1,4 @@
+p.text-blue-900.main-font.text-1xl.container.mx-auto.text-center
+  | 処理中です...お待ちください...
+
 = javascript_pack_tag 'letters/open'

--- a/app/views/send_letters/login.html.slim
+++ b/app/views/send_letters/login.html.slim
@@ -1,0 +1,4 @@
+p.text-blue-900.main-font.text-1xl.container.mx-auto.text-center
+  | 処理中です...お待ちください...
+
+= javascript_pack_tag 'send_letters/login'

--- a/app/views/shared/_header_login.html.slim
+++ b/app/views/shared/_header_login.html.slim
@@ -1,5 +1,5 @@
 header
-  div.text-blue-900.font.text-2xl.tracking-wider.text-center.py-4
+  div.text-blue-900.font.text-2xl.tracking-wider.text-center.py-6
     = link_to top_path do
       p
         | FUTURE LETTER

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,17 +7,22 @@ Rails.application.routes.draw do
       get 'reserve'
     end
   end
-  resources :send_letters, only: %i[create new update edit index destroy]
+  resources :send_letters, only: %i[create new index destroy]
 
   get 'letters/:token', to: 'letters#invite'
-  get 'send_letters/:token', to: 'send_letters#show', as: 'read_letter'
   get 'open', to: 'letters#open'
+  get 'confirm', to: 'letters#confirm'
   get 'message', to: 'letters#message'
+
+  get 'send_letters/:token', to: 'send_letters#show', as: 'read_letter'
+  get 'login', to: 'send_letters#login'
+
   get 'privacy', to: 'home#privacy'
   get 'terms', to: 'home#terms'
   get 'description', to: 'home#description'
   get 'top', to: 'home#top'
   get 'mypage', to: 'home#mypage'
   get 'friend', to: 'home#friend'
+
   post 'callback', to: 'linebot#callback'
 end

--- a/lib/tasks/check_date.rake
+++ b/lib/tasks/check_date.rake
@@ -18,7 +18,7 @@ namespace :check_date do
                   {
                     "type": "uri",
                     "label": "送ったお手紙を確認する",
-                    "uri": "https://liff.line.me/#{liff_id}/send_letters/#{letter.token}"
+                    "uri": "https://liff.line.me/#{liff_id}/login?token=#{letter.token}"
                   }
               ]
           }
@@ -42,7 +42,7 @@ namespace :check_date do
                   {
                     "type": "uri",
                     "label": "お手紙を読む",
-                    "uri": "https://liff.line.me/#{liff_id}/send_letters/#{letter.token}"
+                    "uri": "https://liff.line.me/#{liff_id}/login?token=#{letter.token}"
                   }
               ]
           }
@@ -68,7 +68,7 @@ namespace :check_date do
                   {
                     "type": "uri",
                     "label": "お手紙を確認する",
-                    "uri": "https://liff.line.me/#{liff_id}/letters/#{letter.id}/edit"
+                    "uri": "https://liff.line.me/#{liff_id}/confirm?id=#{letter.id}"
                   }
               ]
           }
@@ -100,7 +100,7 @@ namespace :check_date do
                     {
                       "type": "uri",
                       "label": "お手紙を確認する",
-                      "uri": "https://liff.line.me/#{liff_id}/letters/#{letter.id}/edit"
+                      "uri": "https://liff.line.me/#{liff_id}/confirm?id=#{letter.id}"
                     }
                 ]
             }


### PR DESCRIPTION
## 概要
schedulerで送信された手紙を開いた時、最後にLIFFログインしてから一定時間が過ぎると、手紙が開けずにトップページへ遷移してしまっていました。
LIFFブラウザから一度ログインすると正常に開けてはいましたが、動作を軽減させるため、LIFFログインの処理を挟むよう修正しました。

- LIFFログインしてから手紙を開くよう修正  5c855aa5930147640d9e1f717c4e96b04253fd08 4d1db9011a467fcd6dd712ca74fbcedcef049aa9 62de22bedd1270a4bd78445cccb5baf37cbbf57d
- CSSの修正、不要なコードを削除 3e94cedf6efbee95e4426ab90dea354c26570e84 90d1f7465cfcde1bfe5ec9d4b0855f4963b28531

## 確認方法

1. schedulerで送信された `届いた手紙`、 `自分が送った手紙`、 `送信相手が選択されていなかった手紙`を開いた時、LIFFログインして開くことができること。
