### PR TITLE
Fix：ログイン後の遷移ページ、メニューボタンの遷移ページを変更

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,9 +4,23 @@ Style/FrozenStringLiteralComment:
 Style/Documentation:
   Enabled: false
 
+Metrics/AbcSize:
+  Max: 30
+
 Metrics/BlockLength:
+  Max: 30
   Exclude:
+    - 'Gemfile'
+    - 'config/**/*'
     - 'spec/**/*'
+
+Metrics/ClassLength:
+  CountComments: false
+  Max: 300
+
+Metrics/MethodLength:
+  CountComments: false
+  Max: 30
 
 AllCops:
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'bootsnap', '>= 1.4.4', require: false
 
 gem 'line-bot-api'
 
-gem "aws-sdk-s3", require: false
+gem 'aws-sdk-s3', require: false
 gem 'carrierwave'
 gem 'fog-aws'
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,9 +3,9 @@ class ApplicationController < ActionController::Base
   helper_method :logged_in?
   before_action :login_required
 
-  rescue_from StandardError, with: :render_500
-  rescue_from ActiveRecord::RecordNotFound, with: :render_404
-  rescue_from ActionController::RoutingError, with: :render_404
+  rescue_from StandardError, with: :render500
+  rescue_from ActiveRecord::RecordNotFound, with: :render404
+  rescue_from ActionController::RoutingError, with: :render404
 
   private
 
@@ -21,11 +21,11 @@ class ApplicationController < ActionController::Base
     redirect_to top_path unless current_user
   end
 
-  def render_404
+  def render404
     render file: Rails.root.join('public/404.html'), layout: false, status: :not_found
   end
 
-  def render_500(error = nil)
+  def render500(error = nil)
     logger.error(error.message)
     logger.error(error.backtrace.join('\n'))
     ExceptionNotifier.notify_exception(e, env: request.env, data: { message: 'error' })

--- a/app/controllers/letters_controller.rb
+++ b/app/controllers/letters_controller.rb
@@ -6,7 +6,7 @@ class LettersController < ApplicationController
   require 'uri'
 
   def index
-    @letters = Letter.where(user_id: current_user.id).includes(:user).order("send_date ASC")
+    @letters = Letter.where(user_id: current_user.id).includes(:user).order('send_date ASC')
   end
 
   def invite
@@ -20,22 +20,22 @@ class LettersController < ApplicationController
     @letter.save!(validate: false)
     render json: @letter
     message = {
-      "type": "text",
+      "type": 'text',
       "text": "お手紙の宛先が確認されました！\n設定日時にお手紙が相手へ届きます。"
     }
     client = Line::Bot::Client.new { |config|
-    config.channel_secret = ENV['LINE_CHANNEL_SECRET']
-    config.channel_token = ENV['LINE_CHANNEL_TOKEN']
+      config.channel_secret = ENV['LINE_CHANNEL_SECRET']
+      config.channel_token = ENV['LINE_CHANNEL_TOKEN']
     }
     response = client.push_message(@letter.user.line_user_id, message)
     p response
     message = {
-      "type": "text",
-      "text": "お手紙はサプライズで届きます！\nお楽しみに...!"
+      "type": 'text',
+      "text": "お手紙はサプライズで届きます！$\nお届けまでお楽しみに...!"
     }
     client = Line::Bot::Client.new { |config|
-    config.channel_secret = ENV['LINE_CHANNEL_SECRET']
-    config.channel_token = ENV['LINE_CHANNEL_TOKEN']
+      config.channel_secret = ENV['LINE_CHANNEL_SECRET']
+      config.channel_token = ENV['LINE_CHANNEL_TOKEN']
     }
     response = client.push_message(User.find(session[:user_id]).line_user_id, message)
     p response

--- a/app/controllers/linebot_controller.rb
+++ b/app/controllers/linebot_controller.rb
@@ -1,20 +1,16 @@
 class LinebotController < ApplicationController
   require 'line/bot'
 
-  protect_from_forgery :except => [:callback]
+  protect_from_forgery except: [:callback]
 
   def callback
     client = Line::Bot::Client.new { |config|
-      config.channel_secret = ENV["LINE_CHANNEL_SECRET"]
-      config.channel_token = ENV["LINE_CHANNEL_TOKEN"]
+      config.channel_secret = ENV['LINE_CHANNEL_SECRET']
+      config.channel_token = ENV['LINE_CHANNEL_TOKEN']
     }
     body = request.body.read
     signature = request.env['HTTP_X_LINE_SIGNATURE']
-    unless client.validate_signature(body, signature)
-      head :bad_request
-    end
-
-    events = client.parse_events_from(body)
+    head :bad_request unless client.validate_signature(body, signature)
     head :ok
   end
 end

--- a/app/controllers/send_letters_controller.rb
+++ b/app/controllers/send_letters_controller.rb
@@ -10,7 +10,7 @@ class SendLettersController < ApplicationController
 
   def index
     user = current_user
-    @send_letters = user.letters.joins(:send_letters).order("send_date DESC")
+    @send_letters = user.letters.joins(:send_letters).order('send_date DESC')
   end
 
   def show
@@ -23,17 +23,16 @@ class SendLettersController < ApplicationController
     end
   end
 
-  def new;  end
+  def new; end
 
   def create
-    idToken = params[:idToken]
-    channelId = ENV['CHANNEL_ID']
-    res = Net::HTTP.post_form(URI.parse('https://api.line.me/oauth2/v2.1/verify'),
-                          {'id_token'=>idToken, 'client_id'=>channelId})
-    render :json => res.body
+    id_token = params[:idToken]
+    channel_id = ENV['CHANNEL_ID']
+    res = Net::HTTP.post_form(URI.parse('https://api.line.me/oauth2/v2.1/verify'), { 'id_token' => id_token, 'client_id' => channel_id })
+    render json: res.body
     destination_id = params[:dataId]
     letter = Letter.find_by(token: params[:letterToken])
-    send_letter = SendLetter.new(destination_id: destination_id ,letter_id: letter.id)
+    send_letter = SendLetter.new(destination_id: destination_id, letter_id: letter.id)
     send_letter.save! if SendLetter.find_by(letter_id: letter.id) == nil
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,7 +11,7 @@ class UsersController < ApplicationController
   def create
     id_token = params[:idToken]
     channel_id = ENV['CHANNEL_ID']
-    res = Net::HTTP.post_form(URI.parse('https://api.line.me/oauth2/v2.1/verify'), {'id_token' => id_token, 'client_id' => channel_id})
+    res = Net::HTTP.post_form(URI.parse('https://api.line.me/oauth2/v2.1/verify'), { 'id_token' => id_token, 'client_id' => channel_id })
     line_user_id = JSON.parse(res.body)['sub']
     user = User.find_by(line_user_id: line_user_id)
     if user.nil?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,7 +8,7 @@ module ApplicationHelper
       description: '大切なひと、未来の自分へ、今の気持ちをお手紙に残しませんか？送信日時を設定し、サプライズでお手紙を送るサービスです。',
       keywords: '手紙',
       canonical: request.original_url,
-      noindex: ! Rails.env.production?,
+      noindex: !Rails.env.production?,
       icon: [
         { href: image_url('favicon.ico') },
         { href: image_url('icon_180.jpg'), rel: 'apple-touch-icon', sizes: '180x180', type: 'image/jpg' },

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,7 +8,7 @@ module ApplicationHelper
       description: '大切なひと、未来の自分へ、今の気持ちをお手紙に残しませんか？送信日時を設定し、サプライズでお手紙を送るサービスです。',
       keywords: '手紙',
       canonical: request.original_url,
-      noindex: !Rails.env.production?,
+      noindex: ! Rails.env.production?,
       icon: [
         { href: image_url('favicon.ico') },
         { href: image_url('icon_180.jpg'), rel: 'apple-touch-icon', sizes: '180x180', type: 'image/jpg' },

--- a/app/javascript/packs/users/new.js
+++ b/app/javascript/packs/users/new.js
@@ -27,7 +27,7 @@ document.addEventListener('DOMContentLoaded', () => {
         data_id = data.id
       })
       .then(() => {
-        window.location = '/letters'
+        window.location = '/top'
       })
     })
 })

--- a/app/models/letter.rb
+++ b/app/models/letter.rb
@@ -15,13 +15,13 @@ class Letter < ApplicationRecord
 
   def send_date_check
     if send_date.blank?
-      errors.add(:send_date, "を設定してください")
+      errors.add(:send_date, 'を設定してください')
     elsif self.send_date == nil
-      errors.add(:send_date, "を設定してください")
+      errors.add(:send_date, 'を設定してください')
     elsif self.send_date < Time.now
-      errors.add(:send_date, "は未来の時間を選択してください")
+      errors.add(:send_date, 'は未来の時間を選択してください')
     elsif self.send_date > Time.zone.local(2023, 7, 31, 23, 59)
-      errors.add(:send_date, "は2023年7月31日23時までの時間を選択してください")
+      errors.add(:send_date, 'は2023年7月31日23時までの時間を選択してください')
     end
   end
 end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -14,12 +14,12 @@ class ImageUploader < CarrierWave::Uploader::Base
   end
 
   def extension_allowlist
-    %w(jpg jpeg gif png)
+    %w[jpg jpeg gif png]
   end
 
   def filename
     original_filename if original_filename
   end
 
-  process resize_to_fill: [350, 350, "Center"]
+  process resize_to_fill: [350, 350, 'Center']
 end

--- a/app/views/home/description.html.slim
+++ b/app/views/home/description.html.slim
@@ -41,16 +41,16 @@ h1.text-blue-900.font.text-2xl.tracking-wider.text-center.py-6
   div class="line-it-button" data-lang="ja" data-type="friend" data-env="REAL" data-lineId="@727jqlfj" style="display: none;"
   script src="https://www.line-website.com/social-plugins/js/thirdparty/loader.min.js" async="async" defer="defer"
 
-.flex.justify-center.pt-6
-  .text-blue-900.font.text-1xl.tracking-wider.text-center
-    p
-      | FUTURE LETTER
-      span.main-font
-        | についての
-    p.font
-      | Tweet
-      span.main-font
-        | はこちら
-.flex.justify-center.pt-1
-  <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-show-count="false" data-url="https://future-letter.herokuapp.com/top" data-text="【FUTURE LETTER】 サプライズでお手紙を送るサービスです。">Tweet</a>
-  <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+/ .flex.justify-center.pt-6
+/   .text-blue-900.font.text-1xl.tracking-wider.text-center
+/     p
+/       | FUTURE LETTER
+/       span.main-font
+/         | についての
+/     p.font
+/       | Tweet
+/       span.main-font
+/         | はこちら
+/ .flex.justify-center.pt-1
+/   <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-show-count="false" data-url="https://future-letter.herokuapp.com/top" data-text="【FUTURE LETTER】 サプライズでお手紙を送るサービスです。">Tweet</a>
+/   <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>

--- a/app/views/home/top.html.slim
+++ b/app/views/home/top.html.slim
@@ -94,16 +94,16 @@ h1.text-blue-900.font.text-2xl.tracking-wider.text-center.py-6
   div class="line-it-button" data-lang="ja" data-type="friend" data-env="REAL" data-lineId="@727jqlfj" style="display: none;"
   script src="https://www.line-website.com/social-plugins/js/thirdparty/loader.min.js" async="async" defer="defer"
 
-.flex.justify-center.pt-6
-  .text-blue-900.font.text-1xl.tracking-wider.text-center
-    p
-      | FUTURE LETTER
-      span.main-font
-        | についての
-    p.font
-      | Tweet
-      span.main-font
-        | はこちら
-.flex.justify-center.pt-1
-  <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-show-count="false" data-url="https://future-letter.herokuapp.com/top" data-text="【FUTURE LETTER】サプライズでお手紙を送るサービスです。">Tweet</a>
-  <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+/ .flex.justify-center.pt-6
+/   .text-blue-900.font.text-1xl.tracking-wider.text-center
+/     p
+/       | FUTURE LETTER
+/       span.main-font
+/         | についての
+/     p.font
+/       | Tweet
+/       span.main-font
+/         | はこちら
+/ .flex.justify-center.pt-1
+/   <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-show-count="false" data-url="https://future-letter.herokuapp.com/top" data-text="【FUTURE LETTER】サプライズでお手紙を送るサービスです。">Tweet</a>
+/   <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -25,10 +25,10 @@ header
       p.text-center.text-blue-900.font.text-xs
         | MY PAGE
     li.menu.image.container.shadow-lg.mx-auto.tracking-wider.w-1/3
-      = link_to image_tag('post.jpg'), letters_path
+      = link_to image_tag('post.jpg'), new_letter_path
       p.text-center.text-blue-900.font.text-xs
         | NEW LETTER
     li.menu.image.container.shadow-lg.mx-auto.tracking-wider.w-1/3
-      = link_to image_tag('open_book.jpg'), description_path
+      = link_to image_tag('open_book.jpg'), letters_path
       p.text-center.text-blue-900.font.text-xs
-        | DESCRIPTION
+        | DRAFT LETTER

--- a/lib/tasks/check_date.rake
+++ b/lib/tasks/check_date.rake
@@ -7,49 +7,49 @@ namespace :check_date do
     letters.each do |letter|
       if SendLetter.find_by(letter_id: letter.id).present?
         message = {
-          "type": "template",
-          "altText": "相手へお手紙が送られました。",
+          "type": 'template',
+          "altText": '相手へお手紙が送られました。',
           "template": {
               "thumbnailImageUrl": "https://cdn.pixabay.com/photo/2016/09/10/17/17/letters-1659715_1280.jpg",
-              "type": "buttons",
-              "title": "FUTURE LETTER",
-              "text": "相手へお手紙が送られました！",
+              "type": 'buttons',
+              "title": 'FUTURE LETTER',
+              "text": '相手へお手紙が送られました！',
               "actions": [
                   {
-                    "type": "uri",
-                    "label": "送ったお手紙を確認する",
+                    "type": 'uri',
+                    "label": '送ったお手紙を確認する',
                     "uri": "https://liff.line.me/#{liff_id}/login?token=#{letter.token}"
                   }
               ]
           }
         }
         client = Line::Bot::Client.new { |config|
-            config.channel_secret = ENV['LINE_CHANNEL_SECRET']
-            config.channel_token = ENV['LINE_CHANNEL_TOKEN']
+          config.channel_secret = ENV['LINE_CHANNEL_SECRET']
+          config.channel_token = ENV['LINE_CHANNEL_TOKEN']
         }
         response = client.push_message(letter.user.line_user_id, message)
         p response
 
         message = {
-          "type": "template",
-          "altText": "お手紙が届きました。",
+          "type": 'template',
+          "altText": 'お手紙が届きました。',
           "template": {
               "thumbnailImageUrl": "https://cdn.pixabay.com/photo/2016/09/10/17/17/letters-1659715_1280.jpg",
-              "type": "buttons",
-              "title": "FUTURE LETTER",
-              "text": "お手紙が届いています！",
+              "type": 'buttons',
+              "title": 'FUTURE LETTER',
+              "text": 'お手紙が届いています！',
               "actions": [
                   {
-                    "type": "uri",
-                    "label": "お手紙を読む",
+                    "type": 'uri',
+                    "label": 'お手紙を読む',
                     "uri": "https://liff.line.me/#{liff_id}/login?token=#{letter.token}"
                   }
               ]
           }
         }
         client = Line::Bot::Client.new { |config|
-            config.channel_secret = ENV['LINE_CHANNEL_SECRET']
-            config.channel_token = ENV['LINE_CHANNEL_TOKEN']
+          config.channel_secret = ENV['LINE_CHANNEL_SECRET']
+          config.channel_token = ENV['LINE_CHANNEL_TOKEN']
         }
         address = SendLetter.find_by(letter_id: letter.id)
         destination = User.find(address.destination_id)
@@ -57,17 +57,17 @@ namespace :check_date do
         p response
       else
         message = {
-        "type": "template",
-          "altText": "送信相手が未選択のため、送信予定時刻にお手紙を送れませんでした。",
+          "type": 'template',
+          "altText": '送信相手が未選択のため、送信予定時刻にお手紙を送れませんでした。',
           "template": {
               "thumbnailImageUrl": "https://cdn.pixabay.com/photo/2016/09/10/17/17/letters-1659715_1280.jpg",
-              "type": "buttons",
-              "title": "FUTURE LETTER",
+              "type": 'buttons',
+              "title": 'FUTURE LETTER',
               "text": "送信予定時刻を過ぎました。\n送信時刻の再設定、お手紙を送る相手を選択しましょう。",
               "actions": [
                   {
-                    "type": "uri",
-                    "label": "お手紙を確認する",
+                    "type": 'uri',
+                    "label": 'お手紙を確認する',
                     "uri": "https://liff.line.me/#{liff_id}/confirm?id=#{letter.id}"
                   }
               ]
@@ -89,25 +89,25 @@ namespace :check_date do
     letters.each do |letter|
       if SendLetter.where(letter_id: letter.id).blank?
         message = {
-          "type": "template",
-            "altText": "送信相手が選択されていないお手紙があります。",
+          "type": 'template',
+            "altText": '送信相手が選択されていないお手紙があります。',
             "template": {
                 "thumbnailImageUrl": "https://cdn.pixabay.com/photo/2016/09/10/17/17/letters-1659715_1280.jpg",
-                "type": "buttons",
-                "title": "FUTURE LETTER",
+                "type": 'buttons',
+                "title": 'FUTURE LETTER',
                 "text": "設定した送信日時が近くなりました。\nお手紙を送る相手を選択しましょう。",
                 "actions": [
                     {
-                      "type": "uri",
-                      "label": "お手紙を確認する",
+                      "type": 'uri',
+                      "label": 'お手紙を確認する',
                       "uri": "https://liff.line.me/#{liff_id}/confirm?id=#{letter.id}"
                     }
                 ]
             }
           }
         client = Line::Bot::Client.new{ |config|
-            config.channel_secret = ENV['LINE_CHANNEL_SECRET']
-            config.channel_token = ENV['LINE_CHANNEL_TOKEN']
+          config.channel_secret = ENV['LINE_CHANNEL_SECRET']
+          config.channel_token = ENV['LINE_CHANNEL_TOKEN']
         }
         response = client.push_message(letter.user.line_user_id, message)
         p response


### PR DESCRIPTION
## 概要
リッチメニューからログイン後、下書き一覧へ遷移するようになっていましたが、初めて見る人には分かりづらいと感じたため、トップページへ遷移するよう修正しました。
また、トップページに使い方の説明を載せているため、メニューボタン（画像が3つ並んでいるボタン）から使い方ページへ遷移するのをやめ、マイページ/新規作成ページ/下書き一覧ページへ遷移するよう修正しました。

Twitter共有ボタンは、本リリース後に再度載せることにします。

- ログイン後の遷移ページをトップページへ変更 003556ba0449b7edcfabea23fa0f00d5abe7dd4a
- メニューボタンの遷移先を 変更 8a20965f7627ebc001209ce79c077bc8e25949c5
- RuboCopによる修正 c767202aa2e8a4491f411ae44329879cd7271092
- Twitter共有ボタンをコメントアウト 132ac21aa7449f6a83c02a23aeac844f8d18ae9f

## 確認方法

1. リッチメニューからログイン後、トップページに遷移すること。
2. メニューボタンは、それぞれマイページ/新規作成ページ/下書き一覧ページへ遷移すること。
3. トップページ、使い方ページにTwitter共有ボタンが表示されていないこと。