### PR TITLE
Fix：部分テンプレートへ移行

### DIFF
--- a/app/controllers/letters_controller.rb
+++ b/app/controllers/letters_controller.rb
@@ -31,7 +31,7 @@ class LettersController < ApplicationController
     p response
     message = {
       "type": 'text',
-      "text": "お手紙はサプライズで届きます！$\nお届けまでお楽しみに...!"
+      "text": "お手紙はサプライズで届きます！\nお届けまでお楽しみに...!"
     }
     client = Line::Bot::Client.new { |config|
       config.channel_secret = ENV['LINE_CHANNEL_SECRET']

--- a/app/views/home/description.html.slim
+++ b/app/views/home/description.html.slim
@@ -41,6 +41,7 @@ h1.text-blue-900.font.text-2xl.tracking-wider.text-center.py-6
   div class="line-it-button" data-lang="ja" data-type="friend" data-env="REAL" data-lineId="@727jqlfj" style="display: none;"
   script src="https://www.line-website.com/social-plugins/js/thirdparty/loader.min.js" async="async" defer="defer"
 
+/ 本リリース後に再表示
 / .flex.justify-center.pt-6
 /   .text-blue-900.font.text-1xl.tracking-wider.text-center
 /     p

--- a/app/views/home/top.html.slim
+++ b/app/views/home/top.html.slim
@@ -1,4 +1,4 @@
-div.pt-6
+div.pt-6.px-2
   card.flex.justify-center.items-center
       div.text-center.leading-5
         div.shadow-lg.w-auto
@@ -94,6 +94,7 @@ h1.text-blue-900.font.text-2xl.tracking-wider.text-center.py-6
   div class="line-it-button" data-lang="ja" data-type="friend" data-env="REAL" data-lineId="@727jqlfj" style="display: none;"
   script src="https://www.line-website.com/social-plugins/js/thirdparty/loader.min.js" async="async" defer="defer"
 
+/ 本リリース後に再表示
 / .flex.justify-center.pt-6
 /   .text-blue-900.font.text-1xl.tracking-wider.text-center
 /     p

--- a/app/views/layouts/login.html.slim
+++ b/app/views/layouts/login.html.slim
@@ -9,6 +9,7 @@ html
     link[rel="preconnect" href="https://fonts.gstatic.com"]
     link[href="https://fonts.googleapis.com/css2?family=Zen+Kaku+Gothic+New:wght@400&display=swap" rel="stylesheet"]
     link[href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600&display=swap" rel="stylesheet"]
+    = display_meta_tags(default_meta_tags)
     = csrf_meta_tags
     = csp_meta_tag
     = stylesheet_link_tag 'application', media: 'all'
@@ -20,4 +21,4 @@ html
   body
     = render 'shared/header_login'
     = yield
-    = render 'shared/footer_login'
+    = render 'shared/footer'

--- a/app/views/letters/_form.html.slim
+++ b/app/views/letters/_form.html.slim
@@ -1,0 +1,48 @@
+div.text-blue-900.main-font.text-1xl.tracking-wider.px-3
+  = form_with(model: letter, id: 'form', local: false) do |f|
+    .field.pb-3.text-center.font-black
+      .pb-2
+        = f.label :image
+      .justify-center
+        = f.file_field :image
+        = f.hidden_field :image_cache
+      - if letter.image.present?
+        .pt-2
+          = image_tag(letter.image.url)
+    .field.py-3.text-center
+      .pb-2.font-black
+        = f.label :title
+      .flex.items-center
+        = f.text_field :title, class: "shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline", placeholder: "〇〇〇"
+        span.pl-3.font-black
+          | へ
+    .field.py-3.text-center
+      .pb-2.font-black
+        = f.label :body
+      = f.text_area :body, class: "resize-none shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline", size: "20x8", placeholder: "手紙を書いたよ！いつもありがとう。"
+    .field.py-3.text-center
+      .pb-2.font-black
+        = f.label :send_date
+        br
+      .font.text-1xl
+        = f.datetime_select :send_date, minute_step: 60, default: Time.now + 1.hours, start_year: 2022, end_year: 2023, date_separator: '/', use_month_numbers: true
+
+    #error_explanation
+      = render 'shared/err_msg', letter: letter
+
+    .actions.text-center.py-3
+      = f.submit :手紙を送る相手を選ぶ, class: "m-1 bg-yellow-100 hover:bg-yellow-200 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow"
+
+.text-blue-900.main-font.text-xs.tracking-wider.text-center.pt-3.pb-6
+  p
+    | ※ 画像を選択した場合、動作が遅い場合があります。
+  p
+    | しばらくお待ちください。
+  br
+  p
+    | ※ 自分宛に送信する場合は、
+  p
+    | 事前に自分専用のトークルームを作成して送信してください。
+
+div.text-blue-900.font.text-1xl.tracking-wider.text-center
+  = link_to 'Back', letters_path

--- a/app/views/letters/edit.html.slim
+++ b/app/views/letters/edit.html.slim
@@ -1,53 +1,6 @@
 h1.text-blue-900.font.text-2xl.tracking-wider.text-center.py-6
   | EDIT LETTER
 
-div.text-blue-900.main-font.text-1xl.tracking-wider.px-3
-  = form_with(model: @letter, id: 'form', local: false) do |f|
-    .field.pb-3.text-center.font-black
-      .pb-2
-        = f.label :image
-      .justify-center
-        = f.file_field :image
-        = f.hidden_field :image_cache
-      - if @letter.image.present?
-        .pt-2
-          = image_tag(@letter.image.url)
-    .field.py-3.text-center
-      .pb-2.font-black
-        = f.label :title
-      .flex.items-center
-        = f.text_field :title, class: "shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline", placeholder: "〇〇〇"
-        span.pl-3.font-black
-          | へ
-    .field.py-3.text-center
-      .pb-2.font-black
-        = f.label :body
-      = f.text_area :body, class: "resize-none shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline", size: "20x8", placeholder: "手紙を書いたよ！いつもありがとう。"
-    .field.py-3.text-center
-      .pb-2.font-black
-        = f.label :send_date
-        br
-      .font.text-1xl
-        = f.datetime_select :send_date, minute_step: 60, default: Time.now + 1.hours, start_year: 2022, end_year: 2023, date_separator: '/', use_month_numbers: true
-
-    #error_explanation
-      = render 'shared/err_msg', letter: @letter
-
-    .actions.text-center.py-3
-      = f.submit :手紙を送る相手を選ぶ, class: "m-1 bg-yellow-100 hover:bg-yellow-200 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow"
-
-.text-blue-900.main-font.text-xs.tracking-wider.text-center.pt-3.pb-6
-  p
-    | ※ 画像を選択した場合、動作が遅い場合があります。
-  p
-    | しばらくお待ちください。
-  br
-  p
-    | ※ 自分宛に送信する場合は、
-  p
-    | 事前に自分専用のトークルームを作成して送信してください。
-
-div.text-blue-900.font.text-1xl.tracking-wider.text-center
-  = link_to 'Back', letters_path
+= render 'form', letter: @letter
 
 = javascript_pack_tag 'letters/new'

--- a/app/views/letters/new.html.slim
+++ b/app/views/letters/new.html.slim
@@ -1,53 +1,6 @@
 h1.text-blue-900.font.text-2xl.tracking-wider.text-center.py-6
-  |NEW LETTER
+  | NEW LETTER
 
-div.text-blue-900.main-font.text-1xl.tracking-wider.px-3
-  = form_with(model: @letter, id: 'form', local: false) do |f|
-    .field.pb-3.text-center.font-black
-      .pb-2
-        = f.label :image
-      .justify-center
-        = f.file_field :image
-        = f.hidden_field :image_cache
-      - if @letter.image.present?
-        .pt-2
-          = image_tag(@letter.image.url)
-    .field.py-3.text-center
-      .pb-2.font-black
-        = f.label :title
-      .flex.items-center
-        = f.text_field :title, class: "shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline", placeholder: "〇〇〇"
-        span.pl-3.font-black
-          | へ
-    .field.py-3.text-center
-      .pb-2.font-black
-        = f.label :body
-      = f.text_area :body, class: "resize-none shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline", size: "20x8", placeholder: "手紙を書いたよ！いつもありがとう。"
-    .field.py-3.text-center
-      .pb-2.font-black
-        = f.label :send_date
-        br
-      .font.text-1xl
-        = f.datetime_select :send_date, minute_step: 60, default: Time.now + 1.hours, start_year: 2022, end_year: 2023, date_separator: '/', use_month_numbers: true
-
-    #error_explanation
-      = render 'shared/err_msg', letter: @letter
-
-    .actions.text-center.py-3
-      = f.submit :手紙を送る相手を選ぶ, class: "m-1 bg-yellow-100 hover:bg-yellow-200 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow"
-
-.text-blue-900.main-font.text-xs.tracking-wider.text-center.pt-3.pb-6
-  p
-    | ※ 画像を選択した場合、動作が遅い場合があります。
-  p
-    | しばらくお待ちください。
-  br
-  p
-    | ※ 自分宛に送信する場合は、
-  p
-    | 事前に自分専用のトークルームを作成して送信してください。
-
-div.text-blue-900.font.text-1xl.tracking-wider.text-center
-  = link_to 'Back', letters_path
+= render 'form', letter: @letter
 
 = javascript_pack_tag 'letters/new'

--- a/app/views/send_letters/index.html.slim
+++ b/app/views/send_letters/index.html.slim
@@ -9,7 +9,7 @@ h1.text-blue-900.font.text-2xl.tracking-wider.text-center.py-6
 
 - if @send_letters.present?
   - @send_letters.each do |send_letter|
-    div.place-items-auto.py-3
+    div.place-items-auto.pt-3
       div.text-center.text-blue-900.font.text-base.pb-1
         = l send_letter.send_date
         br
@@ -21,7 +21,7 @@ h1.text-blue-900.font.text-2xl.tracking-wider.text-center.py-6
           div.text-blue-900.font
             = link_to 'Destroy', send_letter, method: :delete, data: { confirm: "削除してもよろしいですか?" }, class: "m-1 bg-pink-100 hover:bg-pink-200 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow"
 - else
-  p.text-blue-900.font.text-1xl.tracking-wider.text-center
+  p.text-blue-900.font.text-1xl.tracking-wider.text-center.pt-3
     | nothing...
 
 = javascript_pack_tag 'send_letters/index'

--- a/app/views/shared/_err_msg.html.slim
+++ b/app/views/shared/_err_msg.html.slim
@@ -1,4 +1,4 @@
 ul
-  - @letter.errors.full_messages.each do |msg|
+  - letter.errors.full_messages.each do |msg|
     li.text-red-400.main-font.text-sm.font-bold.bg-red-100.relative.px-3.py-3
       = msg

--- a/app/views/shared/_footer_login.html.slim
+++ b/app/views/shared/_footer_login.html.slim
@@ -1,7 +1,0 @@
-footer.py-6
-  .copyright.font.text-center.text-blue-900
-    p.text-xs
-      | App photo and illustration by
-      = link_to 'icons8', 'https://icons8.com/'
-    p
-      | Copyright © 2022  FUTURE LETTER


### PR DESCRIPTION
## 概要
手紙作成/手紙編集のフォームを部分テンプレートへ移行しました。
また、ログイン前後でフッターの表示内容を変える予定でしたが、最終的に同じものを表示させることになったため、使用するファイルを統一しました。
- 部分テンプレートへ移行 b497ee2773b06f2c2bdca3e81c6e06d2e9703020 cebf6e9dc5d472363c06670811fb67668170e006
- CSSの修正 065b669315b15878667eea8cecfd234458725e49
- フッターを統一 98e4799c3296e566c272b357f302472d0c87e7c3

## 確認方法

1. 手紙作成/手紙編集ページが問題なく表示されること。
2. ログイン前後でフッターの表示が変わらないこと、問題なく表示されること。