### PR TITLE
Fix：削除ボタンのAjax化

### DIFF
--- a/app/controllers/letters_controller.rb
+++ b/app/controllers/letters_controller.rb
@@ -87,10 +87,6 @@ class LettersController < ApplicationController
 
   def destroy
     @letter.destroy!
-    respond_to do |format|
-      format.html { redirect_to letters_url }
-      format.json { head :no_content }
-    end
   end
 
   def open

--- a/app/controllers/send_letters_controller.rb
+++ b/app/controllers/send_letters_controller.rb
@@ -1,5 +1,6 @@
 class SendLettersController < ApplicationController
   skip_before_action :login_required, only: %i[login]
+  before_action :set_letter, only: %i[destroy]
 
   require 'net/http'
   require 'uri'
@@ -34,5 +35,21 @@ class SendLettersController < ApplicationController
     letter = Letter.find_by(token: params[:letterToken])
     send_letter = SendLetter.new(destination_id: destination_id, letter_id: letter.id)
     send_letter.save! if SendLetter.find_by(letter_id: letter.id) == nil
+  end
+
+  def destroy
+    @send_letter.destroy!
+  end
+
+  private
+
+  def set_letter
+    @send_letter = Letter.find(params[:id])
+    user = @send_letter.user
+    if user != current_user
+      respond_to do |format|
+        format.html { render file: "#{Rails.root}/public/404.html", layout: false, status: :not_found }
+      end
+    end
   end
 end

--- a/app/controllers/send_letters_controller.rb
+++ b/app/controllers/send_letters_controller.rb
@@ -20,7 +20,7 @@ class SendLettersController < ApplicationController
     if @letter.user || send_letter.destination == current_user
       render layout: 'login'
     else
-      redirect_to(top_path) unless user == current_user
+      redirect_to(top_path) 
     end
   end
 

--- a/app/views/letters/_letter.html.slim
+++ b/app/views/letters/_letter.html.slim
@@ -1,20 +1,21 @@
 - if SendLetter.where(letter_id: letter.id).blank?
   .flex.justify-center.items-center.p-3
-    div.text-center.leading-5
-      div.shadow-lg.w-full
-        - if letter.image.present?
-          = link_to edit_letter_path(letter) do
-            = image_tag letter.image.to_s
-        - else
-          = link_to image_tag('default.jpg'), edit_letter_path(letter)
+    div id="letter-#{letter.id}"
+      div.text-center.leading-5
+        div.shadow-lg.w-full
+          - if letter.image.present?
+            = link_to edit_letter_path(letter) do
+              = image_tag letter.image.to_s
+          - else
+            = link_to image_tag('default.jpg'), edit_letter_path(letter)
 
-        div.text-blue-900.font.text-1xl.px-4.py-2
-          = link_to edit_letter_path(letter) do
-            = l letter.send_date
-            br
-          div.main-font.px-4.py-2
-            = letter.title
-            span.text-blue-900.main-font.text-xs
-              | へ
-          div.text-blue-900.font.m-5
-            = link_to 'Destroy', letter, method: :delete, data: { confirm: "まだ送信していないお手紙です。\n削除してもよろしいですか?" }, class: "m-1 bg-pink-100 hover:bg-pink-200 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow"
+          div.text-blue-900.font.text-1xl.px-4.py-2
+            = link_to edit_letter_path(letter) do
+              = l letter.send_date
+              br
+            div.main-font.px-4.py-2
+              = letter.title
+              span.text-blue-900.main-font.text-xs
+                | へ
+            div.text-blue-900.font.m-5
+              = link_to 'Destroy', letter_path(letter.id), method: :delete, data: { confirm: "まだ送信していないお手紙です。\n削除してもよろしいですか?" }, remote: true, class: "m-1 bg-pink-100 hover:bg-pink-200 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow"

--- a/app/views/letters/destroy.js.erb
+++ b/app/views/letters/destroy.js.erb
@@ -1,0 +1,1 @@
+$('#letter-<%= @letter.id %>').remove()

--- a/app/views/letters/invite.html.slim
+++ b/app/views/letters/invite.html.slim
@@ -24,5 +24,5 @@ card.flex.justify-center.items-center.py-3
         span.main-font.text-xs
           | へ
 
-div.text-blue-900.font.text-center
+.text-blue-900.font.text-center.mt-3
   = link_to "OK", reserve_letter_path(@letter.id), id: 'ok', remote: true, data: { confirm: "FUTURE LETTER 公式アカウントより\n後日お手紙が届きます。よろしいですか?" }, class: "m-1 bg-pink-100 hover:bg-pink-200 border border-blue-900 rounded-full shadow py-2 px-4"

--- a/app/views/send_letters/destroy.js.erb
+++ b/app/views/send_letters/destroy.js.erb
@@ -1,0 +1,1 @@
+$('#letter-<%= @send_letter.id %>').remove()

--- a/app/views/send_letters/index.html.slim
+++ b/app/views/send_letters/index.html.slim
@@ -3,9 +3,14 @@ h1.text-blue-900.font.text-2xl.tracking-wider.text-center.py-6
 
 .text-blue-900.main-font.text-xs.tracking-wider.text-center.pb-3
   p
-    | 送信相手が登録されているため、手紙の編集は行えません。
+    | ※ 送信相手が登録されているため、
   p
-    | ※ 手紙を削除する場合は、手紙が送られてから行ってください。
+    | 手紙の編集/削除は行えません。
+  / 送信済みの手紙を削除できるようにするか本リリース前に決める。
+  / p
+  /   | 送信相手が登録されているため、手紙の編集は行えません。
+  / p
+  /   | ※ 手紙を削除する場合は、手紙が送られてから行ってください。
 
 - if @send_letters.present?
   - @send_letters.each do |send_letter|
@@ -18,9 +23,10 @@ h1.text-blue-900.font.text-2xl.tracking-wider.text-center.py-6
           div.text-center.text-blue-900.main-font.text-base
             = link_to send_letter.title + " " + "へ", read_letter_path(send_letter.token), class: "bg-yellow-100 py-2 px-4 border border-blue-900 rounded-full shadow hover:bg-yellow-200"
             br
-          - if send_letter.send_date <= Time.now
-            div.text-blue-900.font
-              = link_to 'Destroy', letter_path(send_letter.id), method: :delete, data: { confirm: "削除してもよろしいですか?" }, remote: true, class: "m-1 bg-pink-100 hover:bg-pink-200 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow"
+          / 送信済みの手紙を削除できるようにするか本リリース前に決める。
+          / - if send_letter.send_date <= Time.now
+          /   div.text-blue-900.font
+          /     = link_to 'Destroy', letter_path(send_letter.id), method: :delete, data: { confirm: "削除してもよろしいですか?" }, remote: true, class: "m-1 bg-pink-100 hover:bg-pink-200 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow"
 - else
   p.text-blue-900.font.text-1xl.tracking-wider.text-center.pt-3
     | nothing...

--- a/app/views/send_letters/index.html.slim
+++ b/app/views/send_letters/index.html.slim
@@ -9,17 +9,18 @@ h1.text-blue-900.font.text-2xl.tracking-wider.text-center.py-6
 
 - if @send_letters.present?
   - @send_letters.each do |send_letter|
-    div.place-items-auto.pt-3
-      div.text-center.text-blue-900.font.text-base.pb-1
-        = l send_letter.send_date
-        br
-      .flex.justify-center.my-2
-        div.text-center.text-blue-900.main-font.text-base
-          = link_to send_letter.title + " " + "へ", read_letter_path(send_letter.token), class: "bg-yellow-100 py-2 px-4 border border-blue-900 rounded-full shadow hover:bg-yellow-200"
+    div id="letter-#{send_letter.id}"
+      div.place-items-auto.pt-3
+        div.text-center.text-blue-900.font.text-base.pb-1
+          = l send_letter.send_date
           br
-        - if send_letter.send_date <= Time.now
-          div.text-blue-900.font
-            = link_to 'Destroy', send_letter, method: :delete, data: { confirm: "削除してもよろしいですか?" }, class: "m-1 bg-pink-100 hover:bg-pink-200 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow"
+        .flex.justify-center.my-2
+          div.text-center.text-blue-900.main-font.text-base
+            = link_to send_letter.title + " " + "へ", read_letter_path(send_letter.token), class: "bg-yellow-100 py-2 px-4 border border-blue-900 rounded-full shadow hover:bg-yellow-200"
+            br
+          - if send_letter.send_date <= Time.now
+            div.text-blue-900.font
+              = link_to 'Destroy', letter_path(send_letter.id), method: :delete, data: { confirm: "削除してもよろしいですか?" }, remote: true, class: "m-1 bg-pink-100 hover:bg-pink-200 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow"
 - else
   p.text-blue-900.font.text-1xl.tracking-wider.text-center.pt-3
     | nothing...


### PR DESCRIPTION
## 概要
下書き中の手紙の削除ボタンをAjax化しました。
また、送信済みの手紙を削除すると、送信相手も手紙を読めなくなってしまうため、削除ボタンをコメントアウトしました。

- 削除ボタンのAjax化 058e5a8fc127c2fb5dd435ea07d1576b32fbe6fc
- 送信済みの手紙も削除できないよう修正 1529aa5d00a6b1b0179d5a792d73e1394d516ac8
- CSSの修正 d32dfac63b26c815c7a8c2f4ac38bccd99c236b4

## 確認方法

1. 下書き中の手紙を削除した際、Ajaxで削除できることをご確認ください。
2. 送信済み/送信予定ページにある手紙は削除できないことをご確認ください。

## コメント
手紙の削除ボタンに関しては、手紙の保存方法や削除ボタンの必要性について再検討し、再表示するかどうか決めます。