### PR TITLE
Fix：手紙の宛名と本文に文字列長の検証を追加、手紙の見た目を修正

### DIFF
--- a/app/models/letter.rb
+++ b/app/models/letter.rb
@@ -6,8 +6,8 @@ class Letter < ApplicationRecord
   # belongs_to :template
 
   validates :user_id, presence: true
-  validates :title, presence: true
-  validates :body, presence: true
+  validates :title, presence: true, length: { maximum: 30 }
+  validates :body, presence: true, length: { maximum: 3500 }
   validates :send_date, presence: true
   validates :token, presence: true
   validate :send_date_check

--- a/app/views/send_letters/show.html.slim
+++ b/app/views/send_letters/show.html.slim
@@ -1,17 +1,17 @@
 card.flex.justify-center.items-center
-  div.leading-5
-    div.shadow-lg.w-auto
-      div.w-full
-        - if @letter.image.present?
-          = image_tag @letter.image.to_s
-        - else
-          = image_tag('default.jpg')
+  div.shadow-lg.w-auto
+    div.w-full
+      - if @letter.image.present?
+        = image_tag @letter.image.to_s
+      - else
+        = image_tag('default.jpg')
 
-      div.text-blue-900.main-font.text-1xl.pt-6.px-3.text-center
+    .text-blue-900.main-font
+      div.text-1xl.pt-6.px-3.text-center
         = @letter.title
-        span.text-blue-900.main-font.text-xs
+        span.text-xs
           | へ
-      div.text-blue-900.main-font.text-1xl.p-6
+      div.text-1xl.p-6.leading-5
         = safe_join(@letter.body.split("\n"),tag(:br))
 
 div.text-blue-900.font.text-1xl.tracking-wider.text-center.pt-6

--- a/app/views/send_letters/show.html.slim
+++ b/app/views/send_letters/show.html.slim
@@ -1,5 +1,5 @@
 card.flex.justify-center.items-center
-  div.text-center.leading-5
+  div.leading-5
     div.shadow-lg.w-auto
       div.w-full
         - if @letter.image.present?
@@ -7,12 +7,11 @@ card.flex.justify-center.items-center
         - else
           = image_tag('default.jpg')
 
-      div.text-blue-900.main-font.text-1xl.px-4.py-2
+      div.text-blue-900.main-font.text-1xl.pt-6.px-3.text-center
         = @letter.title
         span.text-blue-900.main-font.text-xs
           | へ
-      div.text-blue-900.main-font.text-1xl.px-4.py-2
-        / = @letter.body
+      div.text-blue-900.main-font.text-1xl.p-6
         = safe_join(@letter.body.split("\n"),tag(:br))
 
 div.text-blue-900.font.text-1xl.tracking-wider.text-center.pt-6

--- a/app/views/send_letters/show.html.slim
+++ b/app/views/send_letters/show.html.slim
@@ -12,7 +12,8 @@ card.flex.justify-center.items-center
         span.text-blue-900.main-font.text-xs
           | へ
       div.text-blue-900.main-font.text-1xl.px-4.py-2
-        = @letter.body
+        / = @letter.body
+        = safe_join(@letter.body.split("\n"),tag(:br))
 
 div.text-blue-900.font.text-1xl.tracking-wider.text-center.pt-6
   = link_to 'Back', send_letters_path


### PR DESCRIPTION
## 概要
手紙の宛名は30文字以内、本文は3500文字以内となるよう、文字列長の検証を追加しました。また、safe_joinを使用して改行を表示させるよう変更、手紙の宛名のみ中央寄せにし、本文は左寄せで表示させるようにしました。

- 手紙の宛名と本文に文字列長の検証を追加 6d15935af49bb95f19748eb7b1aa50bc87660655
- 手紙本文の表示にsafe_joinを使用 f4978322292c5bf30a228dcd44073b733d604eaa
- 宛名のみ中央寄せにするよう変更 c09bb98c39eb74333b6c924e7c8620128d186356
- CSSの修正 4ff153f379cefd048bf0754e042018c072df7838

## 確認方法

1. 宛名に30文字以上、本文に3500文字以上を入力するとバリデーションに引っかかりエラーとなることをご確認ください。
2. 改行が反映されること、手紙の宛名は中央寄せ、本文は左寄せとなることをご確認ください。