### PR TITLE
Add：記念日機能の追加

### DIFF
--- a/app/assets/stylesheets/anniversaries.scss
+++ b/app/assets/stylesheets/anniversaries.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the anniversaries controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/anniversaries_controller.rb
+++ b/app/controllers/anniversaries_controller.rb
@@ -1,0 +1,57 @@
+class AnniversariesController < ApplicationController
+  before_action :set_anniversary, only: %i[show edit update destroy]
+
+  def index
+    @anniversaries = Anniversary.where(user_id: current_user.id).includes(:user).order('date DESC')
+  end
+
+  def show; end
+
+  def new
+    @anniversary = Anniversary.new
+  end
+
+  def create
+    @anniversary = Anniversary.new(anniversary_params)
+    @anniversary.user = current_user
+    if @anniversary.save
+      render json: @anniversary
+    else
+      respond_to do |format|
+        format.js { render 'create', status: 400 }
+      end
+    end
+  end
+
+  def edit; end
+
+  def update
+    if @anniversary.update(anniversary_params)
+      render json: @anniversary
+    else
+      respond_to do |format|
+        format.js { render 'update', status: 400 }
+      end
+    end
+  end
+
+  def destroy
+    @anniversary.destroy!
+  end
+
+  private
+
+  def anniversary_params
+    params.require(:anniversary).permit(:user_id, :name, :date, :description)
+  end
+
+  def set_anniversary
+    @anniversary = Anniversary.find(params[:id])
+    user = @anniversary.user
+    if user != current_user
+      respond_to do |format|
+        format.html { render file: "#{Rails.root}/public/404.html", layout: false, status: :not_found }
+      end
+    end
+  end
+end

--- a/app/controllers/letters_controller.rb
+++ b/app/controllers/letters_controller.rb
@@ -10,7 +10,6 @@ class LettersController < ApplicationController
   end
 
   def invite
-    @user = User.find(session[:user_id])
     @letter = Letter.find_by(token: params[:token])
     render layout: 'login'
   end

--- a/app/controllers/letters_controller.rb
+++ b/app/controllers/letters_controller.rb
@@ -71,7 +71,13 @@ class LettersController < ApplicationController
   end
 
   def edit
-    @letter.image.cache! if @letter.image.present?
+    if SendLetter.where(letter_id: @letter.id).blank?
+      @letter.image.cache! if @letter.image.present?
+    else
+      respond_to do |format|
+        format.html { render file: "#{Rails.root}/public/404.html", layout: false, status: :not_found }
+      end
+    end
   end
 
   def update
@@ -98,6 +104,10 @@ class LettersController < ApplicationController
 
   private
 
+  def letter_params
+    params.require(:letter).permit(:title, :body, :image, :image_cache, :user_id, :template_id, :token, :send_date)
+  end
+
   def set_letter
     @letter = Letter.find(params[:id])
     user = @letter.user
@@ -106,9 +116,5 @@ class LettersController < ApplicationController
         format.html { render file: "#{Rails.root}/public/404.html", layout: false, status: :not_found }
       end
     end
-  end
-
-  def letter_params
-    params.require(:letter).permit(:title, :body, :image, :image_cache, :user_id, :template_id, :token, :send_date)
   end
 end

--- a/app/controllers/send_letters_controller.rb
+++ b/app/controllers/send_letters_controller.rb
@@ -17,10 +17,14 @@ class SendLettersController < ApplicationController
   def show
     @letter = Letter.find_by(token: params[:token])
     send_letter = SendLetter.find_by(letter_id: @letter.id)
-    if @letter.user || send_letter.destination_id == current_user
+    if @letter.user == current_user
+      render layout: 'login'
+    elsif send_letter.destination_id == current_user.id
       render layout: 'login'
     else
-      redirect_to(top_path)
+      respond_to do |format|
+        format.html { render file: "#{Rails.root}/public/404.html", layout: false, status: :not_found }
+      end
     end
   end
 

--- a/app/controllers/send_letters_controller.rb
+++ b/app/controllers/send_letters_controller.rb
@@ -17,10 +17,10 @@ class SendLettersController < ApplicationController
   def show
     @letter = Letter.find_by(token: params[:token])
     send_letter = SendLetter.find_by(letter_id: @letter.id)
-    if @letter.user || send_letter.destination == current_user
+    if @letter.user || send_letter.destination_id == current_user
       render layout: 'login'
     else
-      redirect_to(top_path) 
+      redirect_to(top_path)
     end
   end
 

--- a/app/helpers/anniversaries_helper.rb
+++ b/app/helpers/anniversaries_helper.rb
@@ -1,0 +1,2 @@
+module AnniversariesHelper
+end

--- a/app/javascript/packs/anniversaries/index.js
+++ b/app/javascript/packs/anniversaries/index.js
@@ -1,0 +1,39 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const token = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+
+  const LIFF_ID = process.env.LIFF_ID
+  liff.init({
+    liffId: LIFF_ID
+  })
+
+    .then(() => {
+      if (!liff.isLoggedIn()) {
+        liff.login()
+      }
+    })
+
+    .then(() => {
+      const idToken = liff.getIDToken()
+      const body = `idToken=${idToken}`
+      const request = new Request('/users', {
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8',
+          'X-CSRF-Token': token
+        },
+        method: 'POST',
+        body: body
+      });
+
+      fetch(request)
+        .then(response => response.json())
+        .then(data => {
+          data_id = data
+        })
+    })
+
+    .then(() => {
+      if (!liff.isLoggedIn()) {
+        liff.login();
+      }
+    })
+})

--- a/app/javascript/packs/anniversaries/index.js
+++ b/app/javascript/packs/anniversaries/index.js
@@ -30,10 +30,4 @@ document.addEventListener('DOMContentLoaded', () => {
           data_id = data
         })
     })
-
-    .then(() => {
-      if (!liff.isLoggedIn()) {
-        liff.login();
-      }
-    })
 })

--- a/app/javascript/packs/anniversaries/new.js
+++ b/app/javascript/packs/anniversaries/new.js
@@ -1,0 +1,38 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const token = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+
+  const LIFF_ID = process.env.LIFF_ID
+  liff.init({
+    liffId: LIFF_ID
+  })
+    .then(() => {
+      if (!liff.isLoggedIn()) {
+        liff.login();
+      }
+    })
+
+    .then(() => {
+      const idToken = liff.getIDToken()
+      const body = `idToken=${idToken}`
+      const request = new Request('/users', {
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8',
+          'X-CSRF-Token': token
+        },
+        method: 'POST',
+        body: body
+      });
+
+      fetch(request)
+        .then(response => response.json())
+        .then(data => {
+          data_id = data.id
+        })
+    })
+
+  const postFormElm = document.querySelector('#form')
+  postFormElm.addEventListener('ajax:success', function () {
+    alert("保存しました。");
+    window.location = '/anniversaries';
+  })
+})

--- a/app/javascript/packs/anniversaries/show.js
+++ b/app/javascript/packs/anniversaries/show.js
@@ -30,10 +30,4 @@ document.addEventListener('DOMContentLoaded', () => {
           data_id = data.id
         })
     })
-
-    .then(() => {
-      if (!liff.isLoggedIn()) {
-        liff.login();
-      }
-    })
 })

--- a/app/javascript/packs/anniversaries/show.js
+++ b/app/javascript/packs/anniversaries/show.js
@@ -1,0 +1,39 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const token = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+
+  const LIFF_ID = process.env.LIFF_ID
+  liff.init({
+    liffId: LIFF_ID
+  })
+
+    .then(() => {
+      if (!liff.isLoggedIn()) {
+        liff.login();
+      }
+    })
+
+    .then(() => {
+      const idToken = liff.getIDToken();
+      const body = `idToken=${idToken}`
+      const request = new Request('/users', {
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8',
+          'X-CSRF-Token': token
+        },
+        method: 'POST',
+        body: body
+      });
+
+      fetch(request)
+        .then(response => response.json())
+        .then(data => {
+          data_id = data.id
+        })
+    })
+
+    .then(() => {
+      if (!liff.isLoggedIn()) {
+        liff.login();
+      }
+    })
+})

--- a/app/javascript/packs/letters/index.js
+++ b/app/javascript/packs/letters/index.js
@@ -6,11 +6,11 @@ document.addEventListener('DOMContentLoaded', () => {
     liffId: LIFF_ID
   })
 
-    .then(() => {
-      if (!liff.isLoggedIn()) {
-        liff.login()
-      }
-    })
+  .then(() => {
+    if (!liff.isLoggedIn()) {
+      liff.login()
+    }
+  })
 
   .then(() => {
     const idToken = liff.getIDToken()
@@ -29,10 +29,5 @@ document.addEventListener('DOMContentLoaded', () => {
     .then(data => {
       data_id = data
     })
-  })
-  .then(() => {
-    if (!liff.isLoggedIn()) {
-      liff.login();
-    }
   })
 })

--- a/app/javascript/packs/send_letters/index.js
+++ b/app/javascript/packs/send_letters/index.js
@@ -6,11 +6,11 @@ document.addEventListener('DOMContentLoaded', () => {
     liffId: LIFF_ID
   })
 
-    .then(() => {
-      if (!liff.isLoggedIn()) {
-        liff.login()
-      }
-    })
+  .then(() => {
+    if (!liff.isLoggedIn()) {
+      liff.login()
+    }
+  })
 
     .then(() => {
       const idToken = liff.getIDToken()
@@ -29,10 +29,5 @@ document.addEventListener('DOMContentLoaded', () => {
         .then(data => {
           data_id = data
         })
-    })
-    .then(() => {
-      if (!liff.isLoggedIn()) {
-        liff.login();
-      }
     })
 })

--- a/app/javascript/packs/send_letters/show.js
+++ b/app/javascript/packs/send_letters/show.js
@@ -5,11 +5,13 @@ document.addEventListener('DOMContentLoaded', () => {
   liff.init({
     liffId: LIFF_ID
   })
-    .then(() => {
-      if (!liff.isLoggedIn()) {
-        liff.login();
-      }
-    })
+
+  .then(() => {
+    if (!liff.isLoggedIn()) {
+      liff.login();
+    }
+  })
+
     .then(() => {
       const idToken = liff.getIDToken();
       const body = `idToken=${idToken}`
@@ -26,10 +28,5 @@ document.addEventListener('DOMContentLoaded', () => {
         .then(data => {
           data_id = data.id
       })
-    })
-    .then(() => {
-      if (!liff.isLoggedIn()) {
-        liff.login();
-      }
     })
 })

--- a/app/models/anniversary.rb
+++ b/app/models/anniversary.rb
@@ -3,6 +3,7 @@ class Anniversary < ApplicationRecord
 
   validates :user_id, presence: true
   validates :date, presence: true
+  validates :name, presence: true, length: { maximum: 50 }
   validates :description, length: { maximum: 150 }
 
 end

--- a/app/models/anniversary.rb
+++ b/app/models/anniversary.rb
@@ -1,0 +1,8 @@
+class Anniversary < ApplicationRecord
+  belongs_to :user
+
+  validates :user_id, presence: true
+  validates :date, presence: true
+  validates :description, length: { maximum: 150 }
+
+end

--- a/app/views/anniversaries/_anniversary.html.slim
+++ b/app/views/anniversaries/_anniversary.html.slim
@@ -1,0 +1,13 @@
+.flex.justify-center.items-center.p-3.m-auto.break-words
+  div id="anniversary-#{anniversary.id}"
+    .text-center.leading-5.text-blue-900.text-1xl
+      .font.px-4.py-2
+        = link_to edit_anniversary_path(anniversary) do
+          = l anniversary.date, format: :short
+          br
+      .main-font.px-4.py-2
+        = link_to anniversary.name, edit_anniversary_path(anniversary), class: "bg-yellow-100 py-2 px-4 border border-blue-900 rounded-full shadow hover:bg-yellow-200"
+      .main-font.px-4.py-2.max-w-screen-sm
+        = anniversary.description
+      .font.m-5
+        = link_to 'Destroy', anniversary_path(anniversary.id), method: :delete, data: { confirm: "削除してもよろしいですか?" }, remote: true, class: "m-1 bg-pink-100 hover:bg-pink-200 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow"

--- a/app/views/anniversaries/_err_msg.html.slim
+++ b/app/views/anniversaries/_err_msg.html.slim
@@ -1,0 +1,4 @@
+ul
+  - anniversary.errors.full_messages.each do |msg|
+    li.text-red-400.main-font.text-sm.font-bold.bg-red-100.relative.px-3.py-3
+      = msg

--- a/app/views/anniversaries/_form.html.slim
+++ b/app/views/anniversaries/_form.html.slim
@@ -1,0 +1,26 @@
+div.text-blue-900.main-font.text-1xl.tracking-wider.px-3
+  = form_with(model: anniversary, id: 'form', local: false) do |f|
+    .field.py-3.text-center.font
+      .pb-2.font-black
+        = f.label :date
+        br
+      .text-1xl
+        = f.date_select :date, default: Date.today, date_separator: '/', use_month_numbers: true
+    .field.py-3.text-center
+      .pb-2.font-black
+        = f.label :name
+      .flex.items-center
+        = f.text_field :name, class: "shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline", placeholder: "〇〇を始めた日"
+    .field.py-3.text-center
+      .pb-2.font-black
+        = f.label :description
+      = f.text_area :description, class: "resize-none shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline", size: "20x8", placeholder: "〜〜のために、〇〇を始めた日。"
+
+    #error_explanation
+      = render 'err_msg', anniversary: anniversary
+
+    .actions.text-center.py-3
+      = f.submit :保存する, class: "m-1 bg-yellow-100 hover:bg-yellow-200 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow"
+
+div.text-blue-900.font.text-1xl.tracking-wider.text-center
+  = link_to 'Back', anniversaries_path

--- a/app/views/anniversaries/create.js.erb
+++ b/app/views/anniversaries/create.js.erb
@@ -1,0 +1,1 @@
+$('#error_explanation').html("<%= j(render 'err_msg',  anniversary: @anniversary) %>", );

--- a/app/views/anniversaries/destroy.js.erb
+++ b/app/views/anniversaries/destroy.js.erb
@@ -1,0 +1,1 @@
+$('#anniversary-<%= @anniversary.id %>').remove()

--- a/app/views/anniversaries/edit.html.slim
+++ b/app/views/anniversaries/edit.html.slim
@@ -1,0 +1,6 @@
+h1.text-blue-900.font.text-2xl.tracking-wider.text-center.py-6
+  | EDIT ANNIVERSARY
+
+= render 'form', anniversary: @anniversary
+
+= javascript_pack_tag 'anniversaries/new'

--- a/app/views/anniversaries/index.html.slim
+++ b/app/views/anniversaries/index.html.slim
@@ -1,0 +1,14 @@
+h1.text-center.leading-10.container.mx-auto.text-1xl.text-blue-900.main-font.py-6
+  = link_to '記念日を登録する', new_anniversary_path, class: "m-1 bg-yellow-100 hover:bg-yellow-200 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow"
+
+h1.text-blue-900.font.text-2xl.tracking-wider.text-center.pb-6
+  | MY ANNIVERSARY
+
+- if @anniversaries.present?
+  div.place-items-auto
+    = render @anniversaries
+- else
+  p.text-blue-900.font.text-1xl.tracking-wider.text-center
+    | nothing...
+
+= javascript_pack_tag 'anniversaries/index'

--- a/app/views/anniversaries/new.html.slim
+++ b/app/views/anniversaries/new.html.slim
@@ -1,0 +1,6 @@
+h1.text-blue-900.font.text-2xl.tracking-wider.text-center.py-6
+  | NEW ANNIVERSARY
+
+= render 'form', anniversary: @anniversary
+
+= javascript_pack_tag 'anniversaries/new'

--- a/app/views/anniversaries/show.html.slim
+++ b/app/views/anniversaries/show.html.slim
@@ -1,0 +1,12 @@
+.text-blue-900.main-font.text-1xl
+  .pt-6.px-3.text-center.font
+    = @anniversary.date
+  .pt-6.px-3.text-center
+    = @anniversary.name
+  .p-6.leading-5
+    = safe_join(@anniversary.description.split("\n"),tag(:br))
+
+div.text-blue-900.font.text-1xl.tracking-wider.text-center.pt-6
+  = link_to 'Back', anniversaries_path
+
+= javascript_pack_tag 'anniversaries/show'

--- a/app/views/anniversaries/update.js.erb
+++ b/app/views/anniversaries/update.js.erb
@@ -1,0 +1,1 @@
+$('#error_explanation').html("<%= j(render 'err_msg', anniversary: @anniversary) %>", );

--- a/app/views/letters/invite.html.slim
+++ b/app/views/letters/invite.html.slim
@@ -5,6 +5,11 @@
     .text-blue-900.main-font.text-1xl.tracking-wider.text-center
       p
         | お手紙が届くまでお待ちください！
+      .text-xs
+        p
+          | 友だち追加がお済みでない方は
+        p
+          | ページ下部のボタンから友だち追加をしてください。
 
     card.flex.justify-center.items-center.py-3
       div.text-center.leading-5
@@ -12,17 +17,32 @@
           div.w-full
             = image_tag('look_forward.jpg')
 
+    .flex.justify-center.pt-6
+      .text-blue-900.main-font.text-1xl.tracking-wider.text-center
+        p
+          | 友だち追加はこちら
+    .flex.justify-center.pt-1
+      div class="line-it-button" data-lang="ja" data-type="friend" data-env="REAL" data-lineId="@727jqlfj" style="display: none;"
+      script src="https://www.line-website.com/social-plugins/js/thirdparty/loader.min.js" async="async" defer="defer"
+
+    .text-blue-900.main-font.text-xs.tracking-wider.text-center.pt-3
+      p
+        | ※ アプリの操作自体は友だち追加をしなくても行えますが、
+      p
+        | 友だち追加をしないとお手紙は受け取れません。
+
   -else
     .text-blue-900.main-font.text-1xl.tracking-wider.text-center
       p
-        | サプライズでお手紙を送りたいです。
-      p
-        | 表示されているお名前が正しければ
-      p.text-blue-900.font.text-1xl.tracking-wider.text-center
-        | 「OK」
-        span.text-blue-900.main-font.text-1xl.tracking-wider.text-center
-          | を押してください。
-          br
+        | サプライズでお手紙を送りたいです !
+      .text-xs
+        p
+          | 表示されているお名前が正しければ
+        p.font
+          | 「OK」
+          span.main-font
+            | を押してください。
+            br
 
     card.flex.justify-center.items-center.py-3
       div.text-center.leading-5

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -17,3 +17,7 @@ ja:
         name: テンプレート名
         content: テンプレート
       send_letters:
+      anniversary:
+        date: Date
+        name: 記念日名
+        description: 説明

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -4,6 +4,7 @@ ja:
   time:
     formats:
       default: "%Y-%m-%d %H:%M"
+      short: "%Y-%m-%d"
   letters:
     index:
       title: お手紙一覧

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
     end
   end
   resources :send_letters, only: %i[create new index destroy]
+  resources :anniversaries
 
   get 'letters/:token', to: 'letters#invite'
   get 'open', to: 'letters#open'

--- a/db/migrate/20220820173334_create_anniversaries.rb
+++ b/db/migrate/20220820173334_create_anniversaries.rb
@@ -1,0 +1,12 @@
+class CreateAnniversaries < ActiveRecord::Migration[6.1]
+  def change
+    create_table :anniversaries do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :name, null: false
+      t.datetime :date, null: false
+      t.text :description
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_11_062531) do
+ActiveRecord::Schema.define(version: 2022_08_20_173334) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "anniversaries", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "name", null: false
+    t.datetime "date", null: false
+    t.text "description"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_anniversaries_on_user_id"
+  end
 
   create_table "letters", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -51,6 +61,7 @@ ActiveRecord::Schema.define(version: 2022_08_11_062531) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  add_foreign_key "anniversaries", "users"
   add_foreign_key "letters", "templates"
   add_foreign_key "letters", "users"
   add_foreign_key "send_letters", "letters"

--- a/spec/factories/anniversaries.rb
+++ b/spec/factories/anniversaries.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :anniversary do
+    user { nil }
+    name { "MyString" }
+    date { "2022-08-21 02:33:34" }
+    description { "MyText" }
+  end
+end

--- a/spec/helpers/anniversaries_helper_spec.rb
+++ b/spec/helpers/anniversaries_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the AnniversariesHelper. For example:
+#
+# describe AnniversariesHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe AnniversariesHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/anniversary_spec.rb
+++ b/spec/models/anniversary_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Anniversary, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/anniversaries_spec.rb
+++ b/spec/requests/anniversaries_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe "Anniversaries", type: :request do
+  describe "GET /index" do
+    it "returns http success" do
+      get "/anniversaries/index"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /show" do
+    it "returns http success" do
+      get "/anniversaries/show"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /new" do
+    it "returns http success" do
+      get "/anniversaries/new"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /create" do
+    it "returns http success" do
+      get "/anniversaries/create"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /edit" do
+    it "returns http success" do
+      get "/anniversaries/edit"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /update" do
+    it "returns http success" do
+      get "/anniversaries/update"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /destroy" do
+    it "returns http success" do
+      get "/anniversaries/destroy"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/views/anniversaries/create.html.slim_spec.rb
+++ b/spec/views/anniversaries/create.html.slim_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "anniversaries/create.html.slim", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/anniversaries/destroy.html.slim_spec.rb
+++ b/spec/views/anniversaries/destroy.html.slim_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "anniversaries/destroy.html.slim", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/anniversaries/edit.html.slim_spec.rb
+++ b/spec/views/anniversaries/edit.html.slim_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "anniversaries/edit.html.slim", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/anniversaries/index.html.slim_spec.rb
+++ b/spec/views/anniversaries/index.html.slim_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "anniversaries/index.html.slim", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/anniversaries/new.html.slim_spec.rb
+++ b/spec/views/anniversaries/new.html.slim_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "anniversaries/new.html.slim", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/anniversaries/show.html.slim_spec.rb
+++ b/spec/views/anniversaries/show.html.slim_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "anniversaries/show.html.slim", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/anniversaries/update.html.slim_spec.rb
+++ b/spec/views/anniversaries/update.html.slim_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "anniversaries/update.html.slim", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 概要
記念日の登録機能を追加しました。
- Anniversaryモデルの追加 3f78dd4cbdf0a26856d95724959ba174bb1d9d55
- Anniversaryのコントローラー/ビューを追加 6d1fd3cebb1797556eae9f31d9d7413496346eaa 8ef0517f554bf6e4547c79fb6d52d7e0b23a5cf5

他の人の送信済みの手紙のトークンを直打ちしても開けないよう修正しました。また、送信済みの手紙のトークンを直打ちしても作成者も編集ができないよう修正しました。
- 送信済みの手紙のトークンを直打ちしても開けない/編集できないよう修正 8d01be38f030b3982eb89d486110aa472552a7c4
- CSS、文章の修正 6406bc1856e4f5a08b821df88dd603c195058d63

## 確認方法

1. カラムを追加したので `bundle exec rails db:migrate` を実行してください。
2. `/anniversaries`から記念日の登録/編集/削除/一覧表示が出来ること。
3. 他の人の送信済みの手紙のトークンを直打ちしても開けないこと。また、自分の送信済みの手紙のトークンを直打ちしても編集が出来ないこと。

## コメント
記念日の1ヶ月前などに手紙の作成を提案するタスクが出来次第、マイページから記念日登録画面へ遷移できるよう設定します。