### PR TITLE
Add：記念日

### DIFF
--- a/app/controllers/anniversaries_controller.rb
+++ b/app/controllers/anniversaries_controller.rb
@@ -1,4 +1,5 @@
 class AnniversariesController < ApplicationController
+  skip_before_action :login_required, only: %i[write]
   before_action :set_anniversary, only: %i[show edit update destroy]
 
   def index
@@ -37,6 +38,10 @@ class AnniversariesController < ApplicationController
 
   def destroy
     @anniversary.destroy!
+  end
+
+  def write
+    render layout: 'login'
   end
 
   private

--- a/app/javascript/packs/anniversaries/write.js
+++ b/app/javascript/packs/anniversaries/write.js
@@ -1,0 +1,33 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const token = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+
+  const LIFF_ID = process.env.LIFF_ID
+  liff.init({
+    liffId: LIFF_ID
+  })
+    .then(() => {
+      if (!liff.isLoggedIn()) {
+        liff.login();
+      }
+    })
+    .then(() => {
+      const idToken = liff.getIDToken();
+      const body = `idToken=${idToken}`
+      const request = new Request('/users', {
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8',
+          'X-CSRF-Token': token
+        },
+        method: 'POST',
+        body: body
+      });
+
+      fetch(request)
+        .then(() => {
+          const params = new URLSearchParams(window.location.search);
+          const id = params.get('id')
+          const redirect_url = `/anniversaries/${id}/edit`
+          window.location = redirect_url
+        })
+    })
+})

--- a/app/javascript/packs/anniversaries/write.js
+++ b/app/javascript/packs/anniversaries/write.js
@@ -26,7 +26,7 @@ document.addEventListener('DOMContentLoaded', () => {
         .then(() => {
           const params = new URLSearchParams(window.location.search);
           const id = params.get('id')
-          const redirect_url = `/anniversaries/${id}/edit`
+          const redirect_url = `/anniversaries/${id}`
           window.location = redirect_url
         })
     })

--- a/app/views/anniversaries/_anniversary.html.slim
+++ b/app/views/anniversaries/_anniversary.html.slim
@@ -1,13 +1,18 @@
-.flex.justify-center.items-center.p-3.m-auto.break-words
+.flex.justify-center.items-center.m-auto.break-words.pb-9
   div id="anniversary-#{anniversary.id}"
     .text-center.leading-5.text-blue-900.text-1xl
-      .font.px-4.py-2
+      .font.px-3
         = link_to edit_anniversary_path(anniversary) do
           = l anniversary.date, format: :short
           br
-      .main-font.px-4.py-2
-        = link_to anniversary.name, edit_anniversary_path(anniversary), class: "bg-yellow-100 py-2 px-4 border border-blue-900 rounded-full shadow hover:bg-yellow-200"
-      .main-font.px-4.py-2.max-w-screen-sm
-        = anniversary.description
-      .font.m-5
+      .main-font.p-3
+        p
+          | 『
+          span.font-black
+            = link_to anniversary.name, edit_anniversary_path(anniversary)
+            span
+              | 』
+      .main-font.px-3.max-w-screen-sm.text-sm
+        = link_to anniversary.description, edit_anniversary_path(anniversary)
+      .font.m-3.text-sm.pt-3
         = link_to 'Destroy', anniversary_path(anniversary.id), method: :delete, data: { confirm: "削除してもよろしいですか?" }, remote: true, class: "m-1 bg-pink-100 hover:bg-pink-200 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow"

--- a/app/views/anniversaries/_anniversary.html.slim
+++ b/app/views/anniversaries/_anniversary.html.slim
@@ -13,6 +13,6 @@
             span
               | 』
       .main-font.px-3.max-w-screen-sm.text-sm
-        = link_to anniversary.description, edit_anniversary_path(anniversary)
+        = safe_join(anniversary.description.split("\n"),tag(:br))
       .font.m-3.text-sm.pt-3
         = link_to 'Destroy', anniversary_path(anniversary.id), method: :delete, data: { confirm: "削除してもよろしいですか?" }, remote: true, class: "m-1 bg-pink-100 hover:bg-pink-200 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow"

--- a/app/views/anniversaries/_form.html.slim
+++ b/app/views/anniversaries/_form.html.slim
@@ -10,11 +10,11 @@ div.text-blue-900.main-font.text-1xl.tracking-wider.px-3
       .pb-2.font-black
         = f.label :name
       .flex.items-center
-        = f.text_field :name, class: "shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline", placeholder: "〇〇を始めた日"
+        = f.text_field :name, class: "shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline", placeholder: "〇〇を始めた日、〇回目の結婚記念日"
     .field.py-3.text-center
       .pb-2.font-black
         = f.label :description
-      = f.text_area :description, class: "resize-none shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline", size: "20x8", placeholder: "〜〜のために、〇〇を始めた日。"
+      = f.text_area :description, class: "resize-none shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline", size: "20x4", placeholder: "〜〜のために、〇〇を始めた日。結婚して〇回目の記念日。"
 
     #error_explanation
       = render 'err_msg', anniversary: anniversary

--- a/app/views/anniversaries/index.html.slim
+++ b/app/views/anniversaries/index.html.slim
@@ -4,6 +4,28 @@ h1.text-center.leading-10.container.mx-auto.text-1xl.text-blue-900.main-font.py-
 h1.text-blue-900.font.text-2xl.tracking-wider.text-center.pb-6
   | MY ANNIVERSARY
 
+.text-blue-900.main-font.text-1xl.tracking-wider.text-center.pb-6
+  p
+    | 未来の日時で登録すると
+  p
+    | 記念日の
+    span.font
+      | 30
+      span.main-font
+        | 日前に通知が来ます。
+  .text-xs.pt-3
+    p
+      | ※ 通知は
+      span.font
+        | 30
+        span.main-font
+          | 日前になった記念日のみ
+    p
+      | 届く仕様になっておりますが
+    p
+      | 過去の日時で登録することも出来ます。
+
+
 - if @anniversaries.present?
   div.place-items-auto
     = render @anniversaries

--- a/app/views/anniversaries/show.html.slim
+++ b/app/views/anniversaries/show.html.slim
@@ -1,12 +1,23 @@
-.text-blue-900.main-font.text-1xl
-  .pt-6.px-3.text-center.font
-    = @anniversary.date
-  .pt-6.px-3.text-center
-    = @anniversary.name
-  .p-6.leading-5
-    = safe_join(@anniversary.description.split("\n"),tag(:br))
+.flex.justify-center.items-center.m-auto.break-words.pt-6
+  div id="anniversary-#{@anniversary.id}"
+    .text-center.leading-5.text-blue-900.text-1xl
+      .font.px-3
+        = link_to edit_anniversary_path(@anniversary) do
+          = l @anniversary.date, format: :short
+          br
+      .main-font.p-3
+        p
+          | 『
+          span.font-black
+            = link_to @anniversary.name, edit_anniversary_path(@anniversary)
+            span
+              | 』
+      .main-font.px-3.max-w-screen-sm.text-sm
+        = safe_join(@anniversary.description.split("\n"),tag(:br))
+      .font.m-3.text-sm.pt-3
+        = link_to 'Destroy', anniversary_path(@anniversary.id), method: :delete, data: { confirm: "削除してもよろしいですか?" }, remote: true, class: "m-1 bg-pink-100 hover:bg-pink-200 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow"
 
-div.text-blue-900.font.text-1xl.tracking-wider.text-center.pt-6
-  = link_to 'Back', anniversaries_path
+.text-center.leading-10.container.mx-auto.text-1xl.text-blue-900.main-font.py-3
+  = link_to '手紙を書く', new_letter_path, class: "m-1 bg-yellow-100 hover:bg-yellow-200 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow"
 
 = javascript_pack_tag 'anniversaries/show'

--- a/app/views/anniversaries/write.html.slim
+++ b/app/views/anniversaries/write.html.slim
@@ -1,0 +1,4 @@
+p.text-blue-900.main-font.text-1xl.container.mx-auto.text-center
+  | 処理中です...お待ちください...
+
+= javascript_pack_tag 'anniversaries/write'

--- a/app/views/home/mypage.html.slim
+++ b/app/views/home/mypage.html.slim
@@ -20,7 +20,7 @@ div.text-blue-900.main-font.text-1xl.tracking-wider.text-center.font-black
   .flex.justify-center
     .w-6
       = image_tag('mail.jpg')
-    = link_to '記念日（準備中）', mypage_path
+    = link_to '記念日', anniversaries_path
   br
   .flex.justify-center
     .w-6

--- a/app/views/home/mypage.html.slim
+++ b/app/views/home/mypage.html.slim
@@ -5,7 +5,7 @@ div.text-blue-900.main-font.text-1xl.tracking-wider.text-center.font-black
   .flex.justify-center
     .w-6
       = image_tag('mail.jpg')
-    = link_to '新しい手紙を書く', new_letter_path
+    = link_to '手紙を書く', new_letter_path
   br
   .flex.justify-center
     .w-6

--- a/app/views/letters/index.html.slim
+++ b/app/views/letters/index.html.slim
@@ -1,8 +1,14 @@
 h1.text-center.leading-10.container.mx-auto.text-1xl.text-blue-900.main-font.py-6
-  = link_to '新しい手紙を書く', new_letter_path, class: "m-1 bg-yellow-100 hover:bg-yellow-200 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow"
+  = link_to '手紙を書く', new_letter_path, class: "m-1 bg-yellow-100 hover:bg-yellow-200 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow"
 
 h1.text-blue-900.font.text-2xl.tracking-wider.text-center.pb-6
   | DRAFT LETTER
+
+.text-blue-900.main-font.text-xs.tracking-wider.text-center.pb-3
+  p
+    | ※ 下書き中のお手紙は
+  p
+    | 設定した送信日時を迎える前に送信してください。
 
 - if @letters.present?
   div.place-items-auto

--- a/app/views/send_letters/index.html.slim
+++ b/app/views/send_letters/index.html.slim
@@ -19,7 +19,7 @@ h1.text-blue-900.font.text-2xl.tracking-wider.text-center.py-6
         div.text-center.text-blue-900.font.text-base.pb-1
           = l send_letter.send_date
           br
-        .flex.justify-center.my-2
+        .flex.justify-center.my-2.pb-3
           div.text-center.text-blue-900.main-font.text-base
             = link_to send_letter.title + " " + "へ", read_letter_path(send_letter.token), class: "bg-yellow-100 py-2 px-4 border border-blue-900 rounded-full shadow hover:bg-yellow-200"
             br

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,8 @@ Rails.application.routes.draw do
   get 'send_letters/:token', to: 'send_letters#show', as: 'read_letter'
   get 'login', to: 'send_letters#login'
 
+  get 'write', to: 'anniversaries#write'
+
   get 'privacy', to: 'home#privacy'
   get 'terms', to: 'home#terms'
   get 'description', to: 'home#description'

--- a/lib/tasks/check_date.rake
+++ b/lib/tasks/check_date.rake
@@ -34,7 +34,7 @@ namespace :check_date do
           "type": 'template',
           "altText": 'お手紙が届きました。',
           "template": {
-              "thumbnailImageUrl": "https://cdn.pixabay.com/photo/2016/09/10/17/17/letters-1659715_1280.jpg",
+              "thumbnailImageUrl": "https://images.unsplash.com/photo-1605364850023-a917c39f8fe9?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MzV8fGxldHRlcnxlbnwwfHwwfHw%3D&auto=format&fit=crop&w=600&q=60",
               "type": 'buttons',
               "title": 'FUTURE LETTER',
               "text": 'お手紙が届いています！',
@@ -60,7 +60,7 @@ namespace :check_date do
           "type": 'template',
           "altText": '送信相手が未選択のため、送信予定時刻にお手紙を送れませんでした。',
           "template": {
-              "thumbnailImageUrl": "https://cdn.pixabay.com/photo/2016/09/10/17/17/letters-1659715_1280.jpg",
+              "thumbnailImageUrl": "https://images.unsplash.com/photo-1603437873662-dc1f44901825?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MzV8fGNsb3VkfGVufDB8fDB8fA%3D%3D&auto=format&fit=crop&w=600&q=60",
               "type": 'buttons',
               "title": 'FUTURE LETTER',
               "text": "送信予定時刻を過ぎました。\n送信時刻の再設定、お手紙を送る相手を選択しましょう。",
@@ -90,21 +90,21 @@ namespace :check_date do
       if SendLetter.where(letter_id: letter.id).blank?
         message = {
           "type": 'template',
-            "altText": '送信相手が選択されていないお手紙があります。',
-            "template": {
-                "thumbnailImageUrl": "https://cdn.pixabay.com/photo/2016/09/10/17/17/letters-1659715_1280.jpg",
-                "type": 'buttons',
-                "title": 'FUTURE LETTER',
-                "text": "設定した送信日時が近くなりました。\nお手紙を送る相手を選択しましょう。",
-                "actions": [
-                    {
-                      "type": 'uri',
-                      "label": 'お手紙を確認する',
-                      "uri": "https://liff.line.me/#{liff_id}/confirm?id=#{letter.id}"
-                    }
-                ]
-            }
+          "altText": '送信相手が選択されていないお手紙があります。',
+          "template": {
+              "thumbnailImageUrl": "https://images.unsplash.com/photo-1603437873662-dc1f44901825?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MzV8fGNsb3VkfGVufDB8fDB8fA%3D%3D&auto=format&fit=crop&w=600&q=60",
+              "type": 'buttons',
+              "title": 'FUTURE LETTER',
+              "text": "設定した送信日時が近くなりました。\nお手紙を送る相手を選択しましょう。",
+              "actions": [
+                  {
+                    "type": 'uri',
+                    "label": 'お手紙を確認する',
+                    "uri": "https://liff.line.me/#{liff_id}/confirm?id=#{letter.id}"
+                  }
+              ]
           }
+        }
         client = Line::Bot::Client.new{ |config|
           config.channel_secret = ENV['LINE_CHANNEL_SECRET']
           config.channel_token = ENV['LINE_CHANNEL_TOKEN']
@@ -112,6 +112,36 @@ namespace :check_date do
         response = client.push_message(letter.user.line_user_id, message)
         p response
       end
+    end
+  end
+
+  task push_suggest: :environment do
+    liff_id = ENV['LIFF_ID']
+    anniversaries = Anniversary.where('date <= ? and date > ?', Date.today.since(30.days), Date.today.since(29.days))
+    anniversaries.each do |anniversary|
+      message = {
+        "type": 'template',
+        "altText": 'もうすぐ記念日です。',
+        "template": {
+            "thumbnailImageUrl": "https://images.unsplash.com/photo-1603437873662-dc1f44901825?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MzV8fGNsb3VkfGVufDB8fDB8fA%3D%3D&auto=format&fit=crop&w=600&q=60",
+            "type": 'buttons',
+            "title": 'FUTURE LETTER',
+            "text": "記念日の30日前になりました。\nお手紙を書きませんか?",
+            "actions": [
+                {
+                  "type": 'uri',
+                  "label": '記念日を確認する',
+                  "uri": "https://liff.line.me/#{liff_id}/write?id=#{anniversary.id}"
+                }
+            ]
+        }
+      }
+      client = Line::Bot::Client.new{ |config|
+        config.channel_secret = ENV['LINE_CHANNEL_SECRET']
+        config.channel_token = ENV['LINE_CHANNEL_TOKEN']
+      }
+      response = client.push_message(anniversary.user.line_user_id, message)
+      p response
     end
   end
 end

--- a/lib/tasks/check_date.rake
+++ b/lib/tasks/check_date.rake
@@ -10,7 +10,7 @@ namespace :check_date do
           "type": 'template',
           "altText": '相手へお手紙が送られました。',
           "template": {
-              "thumbnailImageUrl": "https://cdn.pixabay.com/photo/2016/09/10/17/17/letters-1659715_1280.jpg",
+              "thumbnailImageUrl": "https://images.unsplash.com/photo-1559057287-ce0f595679a8?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1470&q=80",
               "type": 'buttons',
               "title": 'FUTURE LETTER',
               "text": '相手へお手紙が送られました！',


### PR DESCRIPTION
## 概要
記念日の登録、編集、削除機能を作成しました。また、未来の日時で登録した場合は、30日前になると手紙作成の通知が来るようRakeタスクを追加しました。

- マイページから記念日ページへ遷移するよう修正 b9781f65206ba1fabf5e985d6b5e0241437e1aca
- 記念日の30日前になると手紙作成の通知がされるようRakeタスクを追加 41f575de0636d36d45a0b7dc2fd5ee41dc99a94e
- 記念日の通知を開いた時、ページ遷移前にログイン処理を挟むよう追加 591cffad1c01a423437b2adfba93e46687147a94
- 記念日通知メッセージから記念日のshowへ遷移するよう修正 4e8d0f747c4af1d27d6d1fe752f406d9c459b028
- CSS、文章の修正 d36196186dd0103ba342ced27bd1c3690a6b6548 6ee1c438df1737d6afe5caccf0ff9541ac36f7e0

## 確認方法

1.  マイページの `記念日`から記念日一覧ページへ遷移できることをご確認ください。
2. 記念日の登録/編集/削除ができることをご確認ください。
3. 記念日の30日前になると通知が届き、メッセージを開くと該当する記念日の詳細ページが開かれることをご確認ください。
4. 記念日の詳細ページから、記念日の編集/削除、手紙の作成ページへ遷移できることをご確認ください。
5. LIFFログインから一定の時間が経過した後でも、記念日の通知メッセージから直接LIFFアプリへログインし該当のページを開けることをご確認ください。

