### PR TITLE
Add：届いた手紙一覧ページを作成

### DIFF
--- a/app/controllers/send_letters_controller.rb
+++ b/app/controllers/send_letters_controller.rb
@@ -1,6 +1,5 @@
 class SendLettersController < ApplicationController
   skip_before_action :login_required, only: %i[login]
-  before_action :set_letter, only: %i[destroy]
 
   require 'net/http'
   require 'uri'
@@ -12,6 +11,11 @@ class SendLettersController < ApplicationController
   def index
     user = current_user
     @send_letters = user.letters.joins(:send_letters).order('send_date DESC')
+  end
+
+  def received
+    user = current_user
+    @received_letters = Letter.joins(:send_letters).where(send_letters: { destination_id: user.id }).order('send_date DESC')
   end
 
   def show
@@ -39,10 +43,6 @@ class SendLettersController < ApplicationController
     letter = Letter.find_by(token: params[:letterToken])
     send_letter = SendLetter.new(destination_id: destination_id, letter_id: letter.id)
     send_letter.save! if SendLetter.find_by(letter_id: letter.id) == nil
-  end
-
-  def destroy
-    @send_letter.destroy!
   end
 
   private

--- a/app/views/home/mypage.html.slim
+++ b/app/views/home/mypage.html.slim
@@ -3,6 +3,8 @@ h1.text-blue-900.font.text-2xl.tracking-wider.text-center.py-6
 
 div.text-blue-900.main-font.text-1xl.tracking-wider.text-center.font-black
   .flex.justify-center.pb-3
+    = link_to t('.to_received_page'), received_path, class: "m-1 bg-blue-50 hover:bg-blue-100 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow"
+  .flex.justify-center.pb-3
     = link_to t('.to_sent_letter_page'), send_letters_path, class: "m-1 bg-blue-50 hover:bg-blue-100 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow"
   .flex.justify-center.pb-3
     = link_to t('.to_anniversary_page'), anniversaries_path, class: "m-1 bg-blue-50 hover:bg-blue-100 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow"

--- a/app/views/letters/invite.html.slim
+++ b/app/views/letters/invite.html.slim
@@ -52,7 +52,7 @@
               = image_tag @letter.image.to_s
             - else
               = image_tag('default.jpg')
-          div.text-blue-900.main-font.text-1xl.px-4.py-2
+          div.text-blue-900.main-font.text-1xl.px-3.py-6
             = @letter.title
             span.main-font.text-xs
               | へ

--- a/app/views/send_letters/index.html.slim
+++ b/app/views/send_letters/index.html.slim
@@ -3,18 +3,13 @@ h1.text-blue-900.font.text-2xl.tracking-wider.text-center.py-6
 
 .text-blue-900.main-font.text-1xl.tracking-wider.text-center
   p.pb-3
-    | \ 送信日時を迎えたお手紙はこちら /
+    | \ 送ったお手紙はこちら /
   .pb-3.text-xs
     p
-      | ※ 送信相手が登録されているため、
+      | 自分が送った手紙が送信日時を迎えると表示されます。
+  .pb-3.text-xs
     p
-      | 手紙の編集/削除は行えません。
-
-  / 送信済みの手紙を削除できるようにするか本リリース前に決める。
-  / p
-  /   | 送信相手が登録されているため、手紙の編集は行えません。
-  / p
-  /   | ※ 手紙を削除する場合は、手紙が送られてから行ってください。
+      | ※ 自分宛の手紙のみ削除することができます。
 
 - if @send_letters.present?
   - @send_letters.each do |send_letter|
@@ -28,10 +23,6 @@ h1.text-blue-900.font.text-2xl.tracking-wider.text-center.py-6
             div.text-center.text-blue-900.main-font.text-base
               = link_to send_letter.title + " " + "へ", read_letter_path(send_letter.token), class: "bg-yellow-100 py-2 px-4 border border-blue-900 rounded-full shadow hover:bg-yellow-200"
               br
-            / 送信済みの手紙を削除できるようにするか本リリース前に決める。
-            / - if send_letter.send_date <= Time.now
-            /   div.text-blue-900.font
-            /     = link_to t('defaults.destroy'), letter_path(send_letter.id), method: :delete, data: { confirm: "削除してもよろしいですか?" }, remote: true, class: "m-1 bg-pink-100 hover:bg-pink-200 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow"
 - else
   p.text-blue-900.font.text-1xl.tracking-wider.text-center.pt-3
     = t('defaults.message.no_result')

--- a/app/views/send_letters/received.html.slim
+++ b/app/views/send_letters/received.html.slim
@@ -1,0 +1,27 @@
+h1.text-blue-900.font.text-2xl.tracking-wider.text-center.py-6
+  = t('.title')
+
+.text-blue-900.main-font.text-1xl.tracking-wider.text-center
+  p.pb-3
+    | \ 届いたお手紙はこちら /
+  .pb-3.text-xs
+    p
+      | 相手から届いた手紙が表示されます。
+
+- if @received_letters.present?
+  - @received_letters.each do |received_letter|
+    - if received_letter.send_date <= Time.now
+      - if received_letter.user != current_user
+        div.place-items-auto.pt-3
+          div.text-center.text-blue-900.font.text-base.pb-1
+            = l received_letter.send_date
+            br
+          .flex.justify-center.my-2.pb-3
+            div.text-center.text-blue-900.main-font.text-base
+              = link_to received_letter.title + " " + "へ", read_letter_path(received_letter.token), class: "bg-yellow-100 py-2 px-4 border border-blue-900 rounded-full shadow hover:bg-yellow-200"
+              br
+- else
+  p.text-blue-900.font.text-1xl.tracking-wider.text-center.pt-3
+    = t('defaults.message.no_result')
+
+= javascript_pack_tag 'send_letters/index'

--- a/app/views/send_letters/show.html.slim
+++ b/app/views/send_letters/show.html.slim
@@ -1,20 +1,29 @@
-card.flex.justify-center.items-center
-  div.shadow-lg.w-auto
-    div.w-full
-      - if @letter.image.present?
-        = image_tag @letter.image.to_s
-      - else
-        = image_tag('default.jpg')
+div id="letter-#{@letter.id}"
+  card.flex.justify-center.items-center
+    div.shadow-lg.w-auto
+      div.w-full
+        - if @letter.image.present?
+          = image_tag @letter.image.to_s
+        - else
+          = image_tag('default.jpg')
 
-    .text-blue-900.main-font
-      div.text-1xl.pt-6.px-3.text-center
-        = @letter.title
-        span.text-xs
-          | へ
-      div.text-1xl.p-6.leading-5
-        = safe_join(@letter.body.split("\n"),tag(:br))
+      .text-blue-900.main-font
+        div.text-1xl.pt-6.px-3.text-center
+          = @letter.title
+          span.text-xs
+            | へ
+        div.text-1xl.p-6.leading-5
+          = safe_join(@letter.body.split("\n"),tag(:br))
 
-div.text-blue-900.font.text-1xl.tracking-wider.text-center.pt-6
-  = link_to t('defaults.back'), send_letters_path
+  - if SendLetter.where(letter_id: @letter.id).where(destination_id: current_user.id).present?
+    - if @letter.user == current_user
+      div.text-blue-900.font.flex.justify-center.mt-3
+        = link_to t('defaults.destroy'), letter_path(@letter.id), method: :delete, data: { confirm: t('defaults.message.delete_confirm') }, remote: true, class: "m-1 bg-pink-100 hover:bg-pink-200 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow"
+
+.text-blue-900.font.text-1xl.tracking-wider.text-center.pt-6
+  - if @letter.user == current_user
+    = link_to t('defaults.back'), send_letters_path
+  - else
+    = link_to t('defaults.back'), received_path
 
 = javascript_pack_tag 'send_letters/show'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -28,6 +28,7 @@ ja:
       title: DESCRIPTION
     mypage:
       title: MY PAGE
+      to_received_page: 届いた手紙
       to_sent_letter_page: 送った手紙
       to_anniversary_page: 記念日
       to_description_page: 使い方
@@ -47,3 +48,5 @@ ja:
   send_letters:
     index:
       title: SENT LETTER
+    received:
+      title: MY LETTER

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
       get 'reserve'
     end
   end
-  resources :send_letters, only: %i[create new index destroy]
+  resources :send_letters, only: %i[create new index]
   resources :anniversaries
 
   get 'letters/:token', to: 'letters#invite'
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
 
   get 'send_letters/:token', to: 'send_letters#show', as: 'read_letter'
   get 'login', to: 'send_letters#login'
+  get 'received', to: 'send_letters#received'
 
   get 'write', to: 'anniversaries#write'
 


### PR DESCRIPTION
## 概要

届いた手紙の一覧ページを作成 68cba33ff17c337dabb54504d9b8544cae47c896
一覧ページへの遷移ボタンを追加、自分宛の手紙のみ削除ボタンを表示 d84c56dca5b88c2cdd9b042227e6d7605f7432a7
CSS、文章の修正 a80ce7a5fd5c5e9500ba4df3ead621c0c1b47a34

## 確認方法

1.  `MY PAGE`から届いた手紙一覧、送った手紙一覧ページへ遷移できること。
2. 届いた手紙一覧には、相手から届いた手紙が表示されること。手紙をクリックし、詳細ページへ遷移後に一覧ページへ戻ると「届いた」手紙一覧ページへ遷移できること。
3. 送った手紙一覧には、自分が送った手紙のうち信日時を迎えた手紙のみが表示されること。手紙をクリックし、詳細ページへ遷移後に一覧ページへ戻ると「送った」手紙一覧ページへ遷移できること。
4. 自分から自分へ送った手紙のみ削除ができること。