### PR TITLE
Add：画像削除ボタンを追加、画像の表示位置を調整

### DIFF
--- a/app/controllers/letters_controller.rb
+++ b/app/controllers/letters_controller.rb
@@ -20,7 +20,19 @@ class LettersController < ApplicationController
     render json: @letter
     message = {
       "type": 'text',
-      "text": "お手紙の宛先が確認されました！\n設定日時にお手紙が相手へ届きます。"
+      "text": "お手紙の宛先が確認されました$\n設定日時に相手へお手紙が届きます！お楽しみに$",
+      "emojis": [
+        {
+          "index": 14,
+          "productId": "5ac22bad031a6752fb806d67",
+          "emojiId": "186"
+        },
+        {
+          "index": 38,
+          "productId": "5ac22bad031a6752fb806d67",
+          "emojiId": "143"
+        }
+      ]
     }
     client = Line::Bot::Client.new { |config|
       config.channel_secret = ENV['LINE_CHANNEL_SECRET']
@@ -30,7 +42,19 @@ class LettersController < ApplicationController
     p response
     message = {
       "type": 'text',
-      "text": "お手紙はサプライズで届きます！\nお届けまでお楽しみに...!"
+      "text": "お手紙はサプライズで届きます！\nお届けまでお楽しみに$$",
+      "emojis": [
+        {
+          "index": 26,
+          "productId": "5ac22bad031a6752fb806d67",
+          "emojiId": "070"
+        },
+        {
+          "index": 27,
+          "productId": "5ac22bad031a6752fb806d67",
+          "emojiId": "189"
+        }
+      ]
     }
     client = Line::Bot::Client.new { |config|
       config.channel_secret = ENV['LINE_CHANNEL_SECRET']
@@ -60,7 +84,19 @@ class LettersController < ApplicationController
   def message
     message = {
       "type": 'text',
-      "text": "お手紙の宛先確認メッセージを送りました！\n送信許可があるまでお待ちください。",
+      "text": "お手紙の宛先確認メッセージを送りました$\n相手が送信を許可するまでお待ちください！$",
+      "emojis": [
+        {
+          "index": 19,
+          "productId": "5ac2197b040ab15980c9b43d",
+          "emojiId": "027"
+        },
+        {
+          "index": 41,
+          "productId": "5ac2173d031a6752fb806d56",
+          "emojiId": "202"
+        }
+      ]
     }
     client = Line::Bot::Client.new { |config|
       config.channel_secret = ENV['LINE_CHANNEL_SECRET']
@@ -71,9 +107,7 @@ class LettersController < ApplicationController
   end
 
   def edit
-    if SendLetter.where(letter_id: @letter.id).blank?
-      @letter.image.cache! if @letter.image.present?
-    else
+    if SendLetter.where(letter_id: @letter.id).present?
       respond_to do |format|
         format.html { render file: "#{Rails.root}/public/404.html", layout: false, status: :not_found }
       end
@@ -105,7 +139,7 @@ class LettersController < ApplicationController
   private
 
   def letter_params
-    params.require(:letter).permit(:title, :body, :image, :image_cache, :user_id, :template_id, :token, :send_date)
+    params.require(:letter).permit(:title, :body, :image, :remove_image, :user_id, :template_id, :token, :send_date)
   end
 
   def set_letter

--- a/app/views/anniversaries/_form.html.slim
+++ b/app/views/anniversaries/_form.html.slim
@@ -1,11 +1,10 @@
-div.text-blue-900.main-font.text-1xl.tracking-wider.px-3
+.text-blue-900.main-font.text-1xl.tracking-wider.px-3
   = form_with(model: anniversary, id: 'form', local: false) do |f|
-    .field.py-3.text-center.font
+    .field.pb-3.text-center.font
       .pb-2.font-black
         = f.label :date
         br
-      .text-1xl
-        = f.date_select :date, default: Date.today, date_separator: '/', use_month_numbers: true
+      = f.date_select :date, default: Date.today, date_separator: '/', use_month_numbers: true
     .field.py-3.text-center
       .pb-2.font-black
         = f.label :name
@@ -22,5 +21,5 @@ div.text-blue-900.main-font.text-1xl.tracking-wider.px-3
     .actions.text-center.py-3
       = f.submit t('defaults.save'), class: "m-1 bg-yellow-100 hover:bg-yellow-200 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow"
 
-div.text-blue-900.font.text-1xl.tracking-wider.text-center
-  = link_to t('defaults.back'), anniversaries_path
+  .font.text-center
+    = link_to t('defaults.back'), anniversaries_path

--- a/app/views/home/description.html.slim
+++ b/app/views/home/description.html.slim
@@ -9,19 +9,17 @@ div.px-2
       = t('letters.new.title')
       span.main-font
         | を押します。
-    card.flex.justify-center.items-center
-      div.shadow-lg.w-auto
-        div.w-full
-          = image_tag 'top_page.jpg', size: '350x350'
+    .flex.justify-center.items-center
+      .shadow-lg.w-auto
+        = image_tag 'top_page.jpg', size: '350x350'
     br
     p.font.text-2xl
       | 2.
     p
       | お手紙を書いて送信日時を設定します。
-    card.flex.justify-center.items-center
-      div.shadow-lg.w-auto
-        div.w-full
-          = image_tag 'letter.jpg', size: '350x350'
+    .flex.justify-center.items-center
+      .shadow-lg.w-auto
+        = image_tag 'letter.jpg', size: '350x350'
     br
     p.font.text-2xl
       | 3.
@@ -31,10 +29,9 @@ div.px-2
       | LINE
       span.main-font
         | の友達から選びます。
-    card.flex.justify-center.items-center
-      div.shadow-lg.w-auto
-        div.w-full
-          = image_tag 'friend.jpg', size: '350x350'
+    .flex.justify-center.items-center
+      .shadow-lg.w-auto
+        = image_tag 'friend.jpg', size: '350x350'
     br
     p.font.text-2xl
       | 4.
@@ -42,19 +39,17 @@ div.px-2
       | 相手に宛名の確認と
     p
       | 送信許可をしてもらいます。
-    card.flex.justify-center.items-center
-      div.shadow-lg.w-auto
-        div.w-full
-          = image_tag 'ok.jpg', size: '350x350'
+    .flex.justify-center.items-center
+      .shadow-lg.w-auto
+        = image_tag 'ok.jpg', size: '350x350'
     br
     p.font.text-2xl
       | 5.
     p
       | 設定した日時にお手紙が届きます !
-    card.flex.justify-center.items-center
-      div.shadow-lg.w-auto
-        div.w-full
-          = image_tag 'talk.jpg', size: '350x350'
+    .flex.justify-center.items-center
+      .shadow-lg.w-auto
+        = image_tag 'talk.jpg', size: '350x350'
     br
 
 .text-blue-900.main-font.text-sm.tracking-wider.text-center

--- a/app/views/home/friend.html.slim
+++ b/app/views/home/friend.html.slim
@@ -1,39 +1,38 @@
-div.pt-2
-  card.justify-center.items-center.m-auto.w-1/2
-    div.text-center.leading-5
-      div.shadow-lg.w-auto
-        div.w-full
-          = image_tag('icon.jpg')
+.px-3
+  .flex.justify-center.items-center.m-auto
+    .shadow-lg.w-auto
+      = image_tag 'icon.jpg', size: '700x700'
 
-h1.text-blue-900.font.text-2xl.tracking-wider.text-center.py-6
-  | PLEASE ADD ME
-  br
-  | AS A LINE FRIEND !
-.text-blue-900.main-font.text-1xl.tracking-wider.text-center
-  p
-    | 宛名のご確認ありがとうございました !
+.text-blue-900.tracking-wider.text-center.main-font
+  h1.font.text-2xl.py-6
+    | PLEASE ADD ME
     br
-  p
-    | このお手紙を受け取るには
-.text-blue-900.font.text-1xl.tracking-wider.text-center.font-black.underline
-  = t('defaults.app_name')
-  span.main-font
-    | を
-    span.text-green-600
-      | 友だち追加
-.text-blue-900.main-font.text-1xl.tracking-wider.text-center
-  p
-    | する必要があります。
-  br
-  p
-    | 下のボタンからぜひ追加してください！
+    | AS A LINE FRIEND !
+  .text-1xl
+    p
+      | 宛名のご確認ありがとうございました !
+      br
+    p
+      | このお手紙を受け取るには
+  .font.text-1xl.font-black.underline
+    = t('defaults.app_name')
+    span.main-font
+      | を
+      span.text-green-600
+        | 友だち追加
+  .text-1xl
+    p
+      | する必要があります。
+    br
+    p
+      | 下のボタンからぜひ追加してください！
 
   .flex.justify-center.py-6
     div class="line-it-button" data-lang="ja" data-type="friend" data-env="REAL" data-lineId="@727jqlfj" style="display: none;"
     script src="https://www.line-website.com/social-plugins/js/thirdparty/loader.min.js" async="async" defer="defer"
 
-.text-blue-900.main-font.text-xs.tracking-wider.text-center
-  p
-    | ※ アプリの操作自体は友だち追加をしなくても行えますが、
-  p
-    | 友だち追加をしないとお手紙は受け取れません。
+  .text-xs
+    p
+      | ※ アプリの操作自体は友だち追加をしなくても行えますが、
+    p
+      | 友だち追加をしないとお手紙は受け取れません。

--- a/app/views/home/top.html.slim
+++ b/app/views/home/top.html.slim
@@ -1,14 +1,13 @@
-div.pt-6.px-2
-  card.flex.justify-center.items-center
-      div.text-center.leading-5
-        div.shadow-lg.w-auto
-          div.w-full
-            = image_tag 'icon.jpg', size: '700x700'
-          .text-blue-900.main-font.text-1xl.tracking-wider.text-center.px-4.py-2
-            p
-              | 大切なひと、未来の自分へ
-            p
-              | 今の気持ちを手紙にして送りませんか？
+.pt-6.px-2
+  .flex.justify-center.items-center
+    .text-center.leading-5
+      .shadow-lg.w-auto
+        = image_tag 'icon.jpg', size: '700x700'
+        .text-blue-900.main-font.text-1xl.tracking-wider.text-center.px-4.py-2
+          p
+            | 大切なひと、未来の自分へ
+          p
+            | 今の気持ちを手紙にして送りませんか？
 
 h1.text-blue-900.font.text-2xl.tracking-wider.text-center.py-6
   | WHEN TO USE
@@ -62,19 +61,17 @@ div.px-2
       = t('letters.new.title')
       span.main-font
         | を押します。
-    card.flex.justify-center.items-center
-      div.shadow-lg.w-auto
-        div.w-full
-          = image_tag 'top_page.jpg', size: '350x350'
+    .flex.justify-center.items-center
+      .shadow-lg.w-auto
+        = image_tag 'top_page.jpg', size: '350x350'
     br
     p.font.text-2xl
       | 2.
     p
       | お手紙を書いて送信日時を設定します。
-    card.flex.justify-center.items-center
-      div.shadow-lg.w-auto
-        div.w-full
-          = image_tag 'letter.jpg', size: '350x350'
+    .flex.justify-center.items-center
+      .shadow-lg.w-auto
+        = image_tag 'letter.jpg', size: '350x350'
     br
     p.font.text-2xl
       | 3.
@@ -84,10 +81,9 @@ div.px-2
       | LINE
       span.main-font
         | の友達から選びます。
-    card.flex.justify-center.items-center
-      div.shadow-lg.w-auto
-        div.w-full
-          = image_tag 'friend.jpg', size: '350x350'
+    .flex.justify-center.items-center
+      .shadow-lg.w-auto
+        = image_tag 'friend.jpg', size: '350x350'
     br
     p.font.text-2xl
       | 4.
@@ -95,19 +91,17 @@ div.px-2
       | 相手に宛名の確認と
     p
       | 送信許可をしてもらいます。
-    card.flex.justify-center.items-center
-      div.shadow-lg.w-auto
-        div.w-full
-          = image_tag 'ok.jpg', size: '350x350'
+    .flex.justify-center.items-center
+      .shadow-lg.w-auto
+        = image_tag 'ok.jpg', size: '350x350'
     br
     p.font.text-2xl
       | 5.
     p
       | 設定した日時にお手紙が届きます !
-    card.flex.justify-center.items-center
-      div.shadow-lg.w-auto
-        div.w-full
-          = image_tag 'talk.jpg', size: '350x350'
+    .flex.justify-center.items-center
+      .shadow-lg.w-auto
+        = image_tag 'talk.jpg', size: '350x350'
     br
 
 .text-blue-900.main-font.text-sm.tracking-wider.text-center

--- a/app/views/letters/_form.html.slim
+++ b/app/views/letters/_form.html.slim
@@ -1,14 +1,18 @@
-div.text-blue-900.main-font.text-1xl.tracking-wider.px-3
+.text-blue-900.main-font.text-1xl.tracking-wider.px-3
   = form_with(model: letter, id: 'form', local: false) do |f|
     .field.pb-3.text-center.font-black
       .pb-2
         = f.label :image
       .justify-center
         = f.file_field :image
-        = f.hidden_field :image_cache
       - if letter.image.present?
-        .pt-2
+        .pt-2.flex.justify-center
           = image_tag(letter.image.url)
+        .pt-2
+          = f.check_box :remove_image
+          = f.label :remove_image
+          p.text-xs.font-normal
+            | ※ デフォルト画像へ変更されます。
     .field.py-3.text-center
       .pb-2.font-black
         = f.label :title
@@ -44,5 +48,5 @@ div.text-blue-900.main-font.text-1xl.tracking-wider.px-3
   p
     | 事前に自分専用のトークルームを作成して送信してください。
 
-div.text-blue-900.font.text-1xl.tracking-wider.text-center
+.text-blue-900.font.text-1xl.tracking-wider.text-center
   = link_to t('defaults.back'), letters_path

--- a/app/views/letters/_letter.html.slim
+++ b/app/views/letters/_letter.html.slim
@@ -1,21 +1,22 @@
 - if SendLetter.where(letter_id: letter.id).blank?
   .flex.justify-center.items-center.p-3
     div id="letter-#{letter.id}"
-      div.text-center.leading-5
-        div.shadow-lg.w-full
-          - if letter.image.present?
-            = link_to edit_letter_path(letter) do
-              = image_tag letter.image.to_s
-          - else
-            = link_to image_tag('default.jpg'), edit_letter_path(letter)
+      .text-center.leading-5
+        .shadow-lg.w-auto
+          .flex.justify-center
+            - if letter.image.present?
+              = link_to edit_letter_path(letter) do
+                = image_tag letter.image.to_s
+            - else
+              = link_to image_tag('default.jpg'), edit_letter_path(letter)
 
-          div.text-blue-900.font.text-1xl.px-4.py-2
+          .text-blue-900.font.text-1xl.px-4.py-2
             = link_to edit_letter_path(letter) do
               = l letter.send_date
               br
-            div.main-font.px-4.py-2
+            .main-font.px-4.py-2
               = letter.title
               span.text-blue-900.main-font.text-xs
                 | へ
-            div.text-blue-900.font.m-5
+            .text-blue-900.font.m-5
               = link_to t('defaults.destroy'), letter_path(letter.id), method: :delete, data: { confirm: "まだ送信していないお手紙です。\n" + t('defaults.message.delete_confirm') }, remote: true, class: "m-1 bg-pink-100 hover:bg-pink-200 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow"

--- a/app/views/letters/index.html.slim
+++ b/app/views/letters/index.html.slim
@@ -1,24 +1,25 @@
-h1.text-center.leading-10.container.mx-auto.text-1xl.text-blue-900.main-font.py-6
-  = link_to t('defaults.to_writing_page'), new_letter_path, class: "m-1 bg-yellow-100 hover:bg-yellow-200 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow"
+.text-blue-900.text-center
+  h1.leading-10.container.mx-auto.text-1xl.main-font.py-6
+    = link_to t('defaults.to_writing_page'), new_letter_path, class: "m-1 bg-yellow-100 hover:bg-yellow-200 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow"
 
-h1.text-blue-900.font.text-2xl.tracking-wider.text-center.pb-6
-  = t('.title')
+  h1.font.text-2xl.tracking-wider.pb-6
+    = t('.title')
 
-.text-blue-900.main-font.text-1xl.tracking-wider.text-center.pb-3
-  .pb-3
-    p
-      | \ 下書き中のお手紙はこちら /
-  .pb-3.text-xs
-    p
-      | ※ 送信せずに送信日時を迎えたお手紙は
-    p
-      | 再度送信日時を設定してください。
+  .main-font.text-1xl.tracking-wider.pb-3
+    .pb-3
+      p
+        | \ 下書き中のお手紙はこちら /
+    .pb-3.text-xs
+      p
+        | ※ 送信せずに送信日時を迎えたお手紙は
+      p
+        | 再度送信日時を設定してください。
 
-- if @letters.present?
-  div.place-items-auto
-    = render @letters
-- else
-  p.text-blue-900.font.text-1xl.tracking-wider.text-center
-    = t('defaults.message.no_result')
+  - if @letters.present?
+    div.place-items-auto
+      = render @letters
+  - else
+    p.font.text-1xl.tracking-wider
+      = t('defaults.message.no_result')
 
 = javascript_pack_tag 'letters/index'

--- a/app/views/letters/invite.html.slim
+++ b/app/views/letters/invite.html.slim
@@ -11,11 +11,10 @@
         p
           | ページ下部のボタンから友だち追加をしてください。
 
-    card.flex.justify-center.items-center.py-3
-      div.text-center.leading-5
-        div.shadow-lg.w-auto
-          div.w-full
-            = image_tag('look_forward.jpg')
+    .flex.justify-center.items-center.py-3
+      .text-center.leading-5
+        .shadow-lg.w-auto
+          = image_tag('look_forward.jpg')
 
     .flex.justify-center.pt-6
       .text-blue-900.main-font.text-1xl.tracking-wider.text-center
@@ -44,15 +43,15 @@
             | を押してください。
             br
 
-    card.flex.justify-center.items-center.py-3
-      div.text-center.leading-5
-        div.shadow-lg.w-auto
-          div.w-full
+    .flex.justify-center.items-center.py-3
+      .text-center.leading-5
+        .shadow-lg.w-auto
+          .flex.justify-center
             - if @letter.image.present?
               = image_tag @letter.image.to_s
             - else
               = image_tag('default.jpg')
-          div.text-blue-900.main-font.text-1xl.px-3.py-6
+          .text-blue-900.main-font.text-1xl.px-3.py-6
             = @letter.title
             span.main-font.text-xs
               | へ
@@ -73,8 +72,7 @@
       p
         | 再度送信して欲しいことを送信者へお伝えください！
 
-  card.flex.justify-center.items-center.py-3
-    div.text-center.leading-5
-      div.shadow-lg.w-auto
-        div.w-full
-          = image_tag('expired.jpg')
+  .flex.justify-center.items-center.py-3
+    .text-center.leading-5
+      .shadow-lg.w-auto
+        = image_tag('expired.jpg')

--- a/app/views/send_letters/index.html.slim
+++ b/app/views/send_letters/index.html.slim
@@ -1,26 +1,27 @@
-h1.text-blue-900.font.text-2xl.tracking-wider.text-center.py-6
-  = t('.title')
+.text-blue-900.tracking-wider.text-center
+  h1.font.text-2xl.py-6
+    = t('.title')
 
-.text-blue-900.main-font.text-1xl.tracking-wider.text-center
-  p.pb-3
-    | \ 送ったお手紙はこちら /
-  .pb-3.text-xs
-    p
-      | 自分が送った手紙が送信日時を迎えると表示されます。
-  .pb-3.text-xs
-    p
-      | ※ 自分宛の手紙のみ削除することができます。
+  .main-font.text-1xl
+    p.pb-3
+      | \ 送ったお手紙はこちら /
+    .text-xs
+      p
+        | 自分が送った手紙が送信日時を迎えると表示されます。
+    .pb-3.text-xs
+      p
+        | ※ 自分宛の手紙のみ削除することができます。
 
 - if @send_letters.present?
   - @send_letters.each do |send_letter|
     - if send_letter.send_date <= Time.now
       div id="letter-#{send_letter.id}"
-        div.place-items-auto.pt-3
-          div.text-center.text-blue-900.font.text-base.pb-1
+        .place-items-auto.pt-3.text-blue-900.text-base
+          .text-center.font.pb-1
             = l send_letter.send_date
             br
           .flex.justify-center.my-2.pb-3
-            div.text-center.text-blue-900.main-font.text-base
+            .text-center.main-font
               = link_to send_letter.title + " " + "へ", read_letter_path(send_letter.token), class: "bg-yellow-100 py-2 px-4 border border-blue-900 rounded-full shadow hover:bg-yellow-200"
               br
 - else

--- a/app/views/send_letters/show.html.slim
+++ b/app/views/send_letters/show.html.slim
@@ -1,7 +1,7 @@
 div id="letter-#{@letter.id}"
-  card.flex.justify-center.items-center
-    div.shadow-lg.w-auto
-      div.w-full
+  .flex.justify-center.items-center
+    .shadow-lg.w-auto
+      .flex.justify-center
         - if @letter.image.present?
           = image_tag @letter.image.to_s
         - else

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -1,10 +1,10 @@
 header
   top
-    div.header-title.text-blue-900.font.text-2xl.tracking-wider
+    .header-title.font.text-2xl.tracking-wider.text-blue-900
       = link_to top_path do
         p FUTURE
         p LETTER
-    nav.header-nav.text-blue-900.font.text-xs.tracking-wider
+    nav.header-nav.font.text-xs.tracking-wider.text-blue-900
       ul.header-menu
         li.header-menu
           = link_to privacy_path do
@@ -19,16 +19,16 @@ header
           = link_to t('defaults.contact'), 'https://forms.gle/3QYDYsXKFowwssbA9'
 
 - if logged_in?
-  ul.menu
+  ul.menu.text-center.text-blue-900.font.text-xs
     li.menu.image.container.shadow-lg.mx-auto.tracking-wider.w-1/3
       = link_to image_tag('flower.jpg'), mypage_path
-      p.text-center.text-blue-900.font.text-xs
+      p
         = t('home.mypage.title')
     li.menu.image.container.shadow-lg.mx-auto.tracking-wider.w-1/3
       = link_to image_tag('post.jpg'), new_letter_path
-      p.text-center.text-blue-900.font.text-xs
+      p
         = t('letters.new.title')
     li.menu.image.container.shadow-lg.mx-auto.tracking-wider.w-1/3
       = link_to image_tag('open_book.jpg'), letters_path
-      p.text-center.text-blue-900.font.text-xs
+      p
         = t('letters.index.title')

--- a/app/views/shared/_header_login.html.slim
+++ b/app/views/shared/_header_login.html.slim
@@ -1,3 +1,3 @@
 header
-  div.text-blue-900.font.text-2xl.tracking-wider.text-center.py-6
+  .text-blue-900.font.text-2xl.tracking-wider.text-center.py-6
     = link_to t('defaults.app_name'), top_path

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -13,6 +13,7 @@ ja:
         body: 手紙の本文
         image: 画像
         send_date: 手紙を送る日時
+        remove_image: 画像を取り消す
       template:
         name: テンプレート名
         content: テンプレート


### PR DESCRIPTION
## 概要
手紙作成時に選択した画像を、手紙編集時に取り消すことができるよう、削除ボタンを追加しました。また、本文が長い手紙の場合、LIFFブラウザ以外で開くと画像が左端に寄ってしまっていたのを、中央に表示させるよう修正しました。

 - 選択した画像を取り消しできるようボタンを追加 a0d96d2c97e1bb82c3dfc04f2a08efa1e08d205a

- 本文が長い手紙をLIFFブラウザ以外で開いた場合でも、画像が中央になるよう修正 1eaa44b5a9c1b1e7f68ea45ea61d8f766397cd97

トーク画面へ送られるメッセージ（宛名確認メッセージ）に絵文字を追加しました。
他、CSSの修正を行いました。

- トーク画面に送られるメッセージに絵文字を追加 a0d96d2c97e1bb82c3dfc04f2a08efa1e08d205a

- CSSの修正 c8d637cc14e95b6ff121dd967bd32aed2b898d6b

## 確認方法

1. 画像を選択して下書き保存後、手紙の編集画面を開くと、選択した画像を取り消すボタンが表示されいていること。
2. LIFFブラウザ以外で手紙を開いた場合も、画像が中央に表示されていること。
3. 宛名確認メッセージに絵文字が表示されていること。

## コメント

LIFFブラウザ以外で手紙を開くと、本文の長さに合わせてカードが引き伸ばされてしまうため、今後修正します。