### PR TITLE
Add：Twitterの共有ボタンを表示

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -5,6 +5,6 @@ class Admin::BaseController < ApplicationController
   private
 
   def check_admin
-    redirect_to root_path unless current_user.admin?
+    redirect_to top_path unless current_user.admin?
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,7 +18,7 @@ class ApplicationController < ActionController::Base
   end
 
   def login_required
-    redirect_to root_path unless current_user
+    redirect_to top_path unless current_user
   end
 
   def render404

--- a/app/javascript/packs/users/new.js
+++ b/app/javascript/packs/users/new.js
@@ -27,7 +27,7 @@ document.addEventListener('DOMContentLoaded', () => {
         data_id = data.id
       })
       .then(() => {
-        window.location = '/'
+        window.location = '/top'
       })
     })
 })

--- a/app/views/home/description.html.slim
+++ b/app/views/home/description.html.slim
@@ -65,16 +65,15 @@
     div class="line-it-button" data-lang="ja" data-type="friend" data-env="REAL" data-lineId="@727jqlfj" style="display: none;"
     script src="https://www.line-website.com/social-plugins/js/thirdparty/loader.min.js" async="async" defer="defer"
 
-/ 本リリース後に再表示
-/   .flex.justify-center.pt-6
-/     .font.text-base.tracking-wider.text-center
-/       = t('defaults.app_name')
-/       span.main-font
-/           | についての
-/       p.font
-/         | Tweet
-/         span.main-font
-/           | はこちら
-/   .flex.justify-center.pt-1
-/     <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-show-count="false" data-url="https://future-letter.herokuapp.com/top" data-text="【FUTURE LETTER】 サプライズでお手紙を送るサービスです。">Tweet</a>
-/     <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+  .flex.justify-center.pt-6
+    .font.text-base.tracking-wider.text-center
+      = t('defaults.app_name')
+      span.main-font
+          | についての
+      p.font
+        | Tweet
+        span.main-font
+          | はこちら
+  .flex.justify-center.pt-1
+    <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-show-count="false" data-url="https://future-letter.herokuapp.com/top" data-text="【FUTURE LETTER】 サプライズでお手紙を送るサービスです。">Tweet</a>
+    <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>

--- a/app/views/home/description.html.slim
+++ b/app/views/home/description.html.slim
@@ -76,5 +76,5 @@
 /         span.main-font
 /           | はこちら
 /   .flex.justify-center.pt-1
-/     <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-show-count="false" data-url="https://future-letter.herokuapp.com" data-text="【FUTURE LETTER】 サプライズでお手紙を送るサービスです。">Tweet</a>
+/     <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-show-count="false" data-url="https://future-letter.herokuapp.com/top" data-text="【FUTURE LETTER】 サプライズでお手紙を送るサービスです。">Tweet</a>
 /     <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>

--- a/app/views/home/top.html.slim
+++ b/app/views/home/top.html.slim
@@ -100,16 +100,15 @@
     div class="line-it-button" data-lang="ja" data-type="friend" data-env="REAL" data-lineId="@727jqlfj" style="display: none;"
     script src="https://www.line-website.com/social-plugins/js/thirdparty/loader.min.js" async="async" defer="defer"
 
-  / 本リリース後に再表示
-  / .flex.justify-center.pt-6
-  /   .font.text-base.tracking-wider.text-center
-  /     = t('defaults.app_name')
-  /     span.main-font
-  /       | についての
-  /     p.font
-  /       | Tweet
-  /       span.main-font
-  /         | はこちら
-  / .flex.justify-center.pt-1
-  /   <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-show-count="false" data-url="https://future-letter.herokuapp.com/top" data-text="【FUTURE LETTER】サプライズでお手紙を送るサービスです。">Tweet</a>
-  /   <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+  .flex.justify-center.pt-6
+    .font.text-base.tracking-wider.text-center
+      = t('defaults.app_name')
+      span.main-font
+        | についての
+      p.font
+        | Tweet
+        span.main-font
+          | はこちら
+  .flex.justify-center.pt-1
+    <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-show-count="false" data-url="https://future-letter.herokuapp.com/top" data-text="【FUTURE LETTER】サプライズでお手紙を送るサービスです。">Tweet</a>
+    <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>

--- a/app/views/home/top.html.slim
+++ b/app/views/home/top.html.slim
@@ -111,5 +111,5 @@
   /       span.main-font
   /         | はこちら
   / .flex.justify-center.pt-1
-  /   <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-show-count="false" data-url="https://future-letter.herokuapp.com" data-text="【FUTURE LETTER】サプライズでお手紙を送るサービスです。">Tweet</a>
+  /   <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-show-count="false" data-url="https://future-letter.herokuapp.com/top" data-text="【FUTURE LETTER】サプライズでお手紙を送るサービスです。">Tweet</a>
   /   <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -1,7 +1,7 @@
 header
   top
     .header-title.font.text-2xl.tracking-wider.text-blue-900
-      = link_to root_path do
+      = link_to top_path do
         p FUTURE
         p LETTER
     nav.header-nav.font.text-xs.tracking-wider.text-blue-900

--- a/app/views/shared/_header_login.html.slim
+++ b/app/views/shared/_header_login.html.slim
@@ -1,3 +1,3 @@
 header
   .text-blue-900.font.text-2xl.tracking-wider.text-center.py-6
-    = link_to t('defaults.app_name'), root_path
+    = link_to t('defaults.app_name'), top_path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
-  root 'home#top'
+  root 'users#new'
 
-  resources :users, only: %i[create new]
+  resources :users, only: %i[create]
   resources :letters, only: %i[create new update edit index destroy] do
     member do
       get 'reserve'
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
 
   get 'write', to: 'anniversaries#write'
 
+  get 'top', to: 'home#top'
   get 'privacy', to: 'home#privacy'
   get 'terms', to: 'home#terms'
   get 'description', to: 'home#description'


### PR DESCRIPTION
## 概要

users#newをroot_pathに変更 9253c32d786fb52e0fcf2d27f7c972121d426fa7
Twitterの共有ボタンを表示 f39919246214750e1e70e0b14253aae365e13b5c

## 確認方法

1. root_pathはusers#newへ遷移すること。
2. Twitter共有ボタンからトップページを共有できること。
