### PR TITLE
Add：ログイン処理をサービスクラスへ

### DIFF
--- a/app/controllers/letters_controller.rb
+++ b/app/controllers/letters_controller.rb
@@ -15,9 +15,9 @@ class LettersController < ApplicationController
   end
 
   def reserve
-    @letter = Letter.find(params[:id])
-    @letter.save!(validate: false)
-    render json: @letter
+    letter = Letter.find(params[:id])
+    letter.save!(validate: false)
+    render json: letter
     message = {
       "type": 'text',
       "text": "お手紙の宛先が確認されました$\n設定日時に相手へお手紙が届きます！お楽しみに$",
@@ -38,7 +38,7 @@ class LettersController < ApplicationController
       config.channel_secret = ENV['LINE_CHANNEL_SECRET']
       config.channel_token = ENV['LINE_CHANNEL_TOKEN']
     }
-    response = client.push_message(@letter.user.line_user_id, message)
+    response = client.push_message(letter.user.line_user_id, message)
     p response
     message = {
       "type": 'text',

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,13 +9,11 @@ class UsersController < ApplicationController
   end
 
   def create
-    id_token = params[:idToken]
-    channel_id = ENV['CHANNEL_ID']
-    res = Net::HTTP.post_form(URI.parse('https://api.line.me/oauth2/v2.1/verify'), { 'id_token' => id_token, 'client_id' => channel_id })
-    line_user_id = JSON.parse(res.body)['sub']
-    user = User.find_by(line_user_id: line_user_id)
+    line_user_authenticate = LineUserAuthenticateService.new(params[:idToken])
+    line_user_authenticate.call
+    user = line_user_authenticate.search_user
     if user.nil?
-      user = User.create(line_user_id: line_user_id)
+      user = User.create(line_user_id: line_user_authenticate.line_user_id)
       session[:user_id] = user.id
       render json: user, layout: 'login'
     elsif user

--- a/app/services/line_user_authenticate_service.rb
+++ b/app/services/line_user_authenticate_service.rb
@@ -1,0 +1,17 @@
+class LineUserAuthenticateService
+  attr_reader :line_user_id
+
+  def initialize(id_token)
+    @id_token = id_token
+  end
+
+  def call
+    channel_id = ENV['CHANNEL_ID']
+    res = Net::HTTP.post_form(URI.parse('https://api.line.me/oauth2/v2.1/verify'), { 'id_token' => @id_token, 'client_id' => channel_id })
+    @line_user_id = JSON.parse(res.body)['sub']
+  end
+
+  def search_user
+    User.find_by(line_user_id: @line_user_id)
+  end
+end


### PR DESCRIPTION
## 概要
サービスクラスを作成し、ログイン処理部分を `usersコントローラー`からサービスクラスへ移動させました。
- ログイン処理をサービスクラスへ 14110a4ad352980c4b61663573fbe780b85f5f97

今後サービスクラスへ移動させることを考え、`lettersコントローラー`内の `reserve`アクションのインスタンス変数をローカル変数へ変更しました。
- ローカル変数へ変更 1441fcf55a41a9062085d016f7216c8f2d33eb7b

## 確認方法

1. ログイン処理が発生するページでログインが成功することをご確認ください。
2. 送信相手が手紙のOKボタンを押した後、手紙の作成者・送信相手の両方のトーク画面へ指定のメッセージが届くこと、手紙が送信予定となり下書き一覧から消えることをご確認ください。

## コメント

今後、APIへ処理を投げている箇所全てサービスクラスへ移動させていきます。