### PR TITLE
Fix：Twitter共有時のURLを独自ドメインへ変更

### DIFF
--- a/app/views/home/description.html.slim
+++ b/app/views/home/description.html.slim
@@ -75,5 +75,5 @@
         span.main-font
           | はこちら
   .flex.justify-center.pt-1
-    <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-show-count="false" data-url="https://future-letter.herokuapp.com/top" data-text="【FUTURE LETTER】 サプライズでお手紙を送るサービスです。">Tweet</a>
+    <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-show-count="false" data-url="https://www.future-letter.com/top" data-text="【FUTURE LETTER】サプライズで手紙を送るサービスです。大切なひと、未来の自分へ、今の気持ちを手紙にして送りませんか？">Tweet</a>
     <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>

--- a/app/views/home/top.html.slim
+++ b/app/views/home/top.html.slim
@@ -110,5 +110,5 @@
         span.main-font
           | はこちら
   .flex.justify-center.pt-1
-    <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-show-count="false" data-url="https://future-letter.herokuapp.com/top" data-text="【FUTURE LETTER】サプライズでお手紙を送るサービスです。">Tweet</a>
+    <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-show-count="false" data-url="https://www.future-letter.com/top" data-text="【FUTURE LETTER】サプライズで手紙を送るサービスです。大切なひと、未来の自分へ、今の気持ちを手紙にして送りませんか？">Tweet</a>
     <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>


### PR DESCRIPTION
## 概要

Twitter共有時のURLを独自ドメインへ変更しました。また、共有時の文章を追加しました。 
- Twitter共有時のURLを変更、文章を追加 b0d411ff6fa532d172fa12c189675509108c75a9

## 確認方法

1. Twitter共有時に独自ドメインが表示されていることをご確認ください。
