### PR TITLE
Add：ヘルパーメソッドを追加

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,12 @@
 module ApplicationHelper
+  def default_time(datetime)
+    datetime.strftime("%Y-%m-%d %H:%M")
+  end
+
+  def short_time(datetime)
+    datetime.strftime("%Y-%m-%d")
+  end
+
   def default_meta_tags
     {
       site: 'FUTURE LETTER',

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -62,4 +62,5 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   config.include FactoryBot::Syntax::Methods
+  config.include ApplicationHelper
 end

--- a/spec/system/anniversaries_spec.rb
+++ b/spec/system/anniversaries_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Anniversaries", type: :system do
 
   describe '記念日一覧' do
     it '自分が登録した記念日が表示されること' do
-      expect(page).to have_content anniversary.date.strftime("%Y-%m-%d")
+      expect(page).to have_content short_time(anniversary.date)
       expect(page).to have_content anniversary.name
       expect(current_path).to eq anniversaries_path
     end
@@ -30,7 +30,7 @@ RSpec.describe "Anniversaries", type: :system do
           click_link 'Destroy'
         end
         switch_to_window(windows.last)
-        expect(page).not_to have_content anniversary.date.strftime("%Y-%m-%d")
+        expect(page).not_to have_content short_time(anniversary.date)
         expect(page).not_to have_content anniversary.name
         expect(current_path).to eq anniversaries_path
       end
@@ -50,7 +50,7 @@ RSpec.describe "Anniversaries", type: :system do
 
     context '記念日の日付をクリックした場合' do
       it '記念日の編集ページへ遷移すること' do
-        click_link anniversary.date.strftime("%Y-%m-%d")
+        click_link short_time(anniversary.date)
         switch_to_window(windows.last)
         expect(page).to have_content 'EDIT ANNIVERSARY'
         expect(page).to have_field '記念日名', with: anniversary.name

--- a/spec/system/letters_spec.rb
+++ b/spec/system/letters_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Letters", js: true, type: :system do
 
   describe '下書きの手紙一覧' do
     it '自分が下書き保存した手紙が表示されること' do
-      expect(page).to have_content letter.send_date.strftime("%Y-%m-%d %H:%M")
+      expect(page).to have_content default_time(letter.send_date)
       expect(page).to have_content letter.title
       expect(current_path).to eq letters_path
     end


### PR DESCRIPTION
## 概要
- datetimeに関するヘルパーメソッドを追加し、テスト環境でもApplicationHelperを読み込むよう設定 2bbfd0c96a014889f5a1dd399873ac0ef9f9912c
- strftime使用部分（spec/system/anniversaries_spec.rb、spec/system/letters_spec.rb）をヘルパーメソッドへ変更 d94d74cfe66f22c5e3b9e1354761e4698a23a9e4

## 確認方法

1. `rspec`コマンドで全てのテストが成功することをご確認ください。
