### PR TITLE
Add：デモページの初期設定を作成

### DIFF
--- a/app/assets/stylesheets/demo_pages.scss
+++ b/app/assets/stylesheets/demo_pages.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the demo_pages controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/demo/anniversaries_controller.rb
+++ b/app/controllers/demo/anniversaries_controller.rb
@@ -1,0 +1,5 @@
+class Demo::AnniversariesController < Demo::BaseController
+  def index; end
+  
+  def show; end
+end

--- a/app/controllers/demo/base_controller.rb
+++ b/app/controllers/demo/base_controller.rb
@@ -1,0 +1,4 @@
+class Demo::BaseController < ApplicationController
+  skip_before_action :login_required
+  layout 'demo/layouts/application'
+end

--- a/app/controllers/demo/home_controller.rb
+++ b/app/controllers/demo/home_controller.rb
@@ -1,0 +1,7 @@
+class Demo::HomeController < Demo::BaseController
+  def top; end
+
+  def description; end
+
+  def mypage; end
+end

--- a/app/controllers/demo/letters_controller.rb
+++ b/app/controllers/demo/letters_controller.rb
@@ -1,0 +1,11 @@
+class Demo::LettersController < Demo::BaseController
+  def new; end
+
+  def draft; end
+
+  def received; end
+
+  def send; end
+
+  def show; end
+end

--- a/app/helpers/demo_pages_helper.rb
+++ b/app/helpers/demo_pages_helper.rb
@@ -1,0 +1,2 @@
+module DemoPagesHelper
+end

--- a/app/views/demo/anniversaries/index.html.slim
+++ b/app/views/demo/anniversaries/index.html.slim
@@ -1,0 +1,2 @@
+h1 Demo::Anniversaries#index
+p Find me in app/views/demo/anniversaries/index.html.slim

--- a/app/views/demo/anniversaries/show.html.slim
+++ b/app/views/demo/anniversaries/show.html.slim
@@ -1,0 +1,2 @@
+h1 Demo::Anniversaries#show
+p Find me in app/views/demo/anniversaries/show.html.slim

--- a/app/views/demo/home/description.html.slim
+++ b/app/views/demo/home/description.html.slim
@@ -1,0 +1,2 @@
+h1 Demo::Home#description
+p Find me in app/views/demo/home/description.html.slim

--- a/app/views/demo/home/mypage.html.slim
+++ b/app/views/demo/home/mypage.html.slim
@@ -1,0 +1,2 @@
+h1 Demo::Home#mypage
+p Find me in app/views/demo/home/mypage.html.slim

--- a/app/views/demo/home/top.html.slim
+++ b/app/views/demo/home/top.html.slim
@@ -1,0 +1,2 @@
+h1 Demo::Home#top
+p Find me in app/views/demo/home/top.html.slim

--- a/app/views/demo/layouts/application.html.slim
+++ b/app/views/demo/layouts/application.html.slim
@@ -1,0 +1,24 @@
+doctype html
+html
+  head
+    title
+      = t('defaults.app_name')
+    meta[name="viewport" content="width=device-width,initial-scale=1"]
+    script[charset="utf-8" src="https://static.line-scdn.net/liff/edge/2/sdk.js"]
+    link[rel="preconnect" href="https://fonts.googleapis.com"]
+    link[rel="preconnect" href="https://fonts.gstatic.com"]
+    link[href="https://fonts.googleapis.com/css2?family=Zen+Kaku+Gothic+New:wght@400&display=swap" rel="stylesheet"]
+    link[href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@700&display=swap" rel="stylesheet"]
+    = display_meta_tags(default_meta_tags)
+    = csrf_meta_tags
+    = csp_meta_tag
+    = stylesheet_link_tag 'application', media: 'all'
+    = javascript_pack_tag 'application'
+    link[href="https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css" rel="stylesheet"]
+    script[src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"]
+    - if Rails.env.production?
+      = render 'layouts/google_analytics'
+  body
+    = render 'demo/shared/header'
+    = yield
+    = render 'demo/shared/footer'

--- a/app/views/demo/letters/draft.html.slim
+++ b/app/views/demo/letters/draft.html.slim
@@ -1,0 +1,2 @@
+h1 Demo::Letters#draft
+p Find me in app/views/demo/letters/draft.html.slim

--- a/app/views/demo/letters/new.html.slim
+++ b/app/views/demo/letters/new.html.slim
@@ -1,0 +1,2 @@
+h1 Demo::Letters#new
+p Find me in app/views/demo/letters/new.html.slim

--- a/app/views/demo/letters/received.html.slim
+++ b/app/views/demo/letters/received.html.slim
@@ -1,0 +1,2 @@
+h1 Demo::Letters#received
+p Find me in app/views/demo/letters/received.html.slim

--- a/app/views/demo/letters/send.html.slim
+++ b/app/views/demo/letters/send.html.slim
@@ -1,0 +1,2 @@
+h1 Demo::Letters#send
+p Find me in app/views/demo/letters/send.html.slim

--- a/app/views/demo/letters/show.html.slim
+++ b/app/views/demo/letters/show.html.slim
@@ -1,0 +1,2 @@
+h1 Demo::Letters#show
+p Find me in app/views/demo/letters/show.html.slim

--- a/app/views/demo/shared/_footer.html.slim
+++ b/app/views/demo/shared/_footer.html.slim
@@ -1,0 +1,10 @@
+footer.py-6
+  .copyright.font.text-center.text-blue-900
+    p.text-xs
+      | App photo and illustration by
+      span
+        = link_to ' icons8', 'https://icons8.com/'
+    p
+      | Copyright © 2022
+      span
+        = " " + t('defaults.app_name')

--- a/app/views/demo/shared/_header.html.slim
+++ b/app/views/demo/shared/_header.html.slim
@@ -1,0 +1,33 @@
+header
+  top
+    .header-title.font.text-2xl.tracking-wider.text-blue-900
+      = link_to demo_root_path do
+        p FUTURE
+        p LETTER
+    nav.header-nav.font.text-xs.tracking-wider.text-blue-900
+      ul.header-menu
+        li.header-menu
+          = link_to privacy_path do
+            p PRIVACY
+            p POLICY
+        li.header-menu
+          = link_to terms_path do
+            p TERMS
+            p OF
+            p SERVICE
+        li.header-menu
+          = link_to t('defaults.contact'), 'https://forms.gle/3QYDYsXKFowwssbA9'
+
+ul.menu.text-center.text-blue-900.font.text-xs
+  li.menu.image.container.shadow-lg.mx-auto.tracking-wider.w-1/3
+    = link_to image_tag('flower.jpg'), demo_mypage_path
+    p
+      = t('home.mypage.title')
+  li.menu.image.container.shadow-lg.mx-auto.tracking-wider.w-1/3
+    = link_to image_tag('post.jpg'), demo_new_letter_path
+    p
+      = t('letters.new.title')
+  li.menu.image.container.shadow-lg.mx-auto.tracking-wider.w-1/3
+    = link_to image_tag('open_book.jpg'), demo_draft_letter_path
+    p
+      = t('letters.index.title')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,4 +38,16 @@ Rails.application.routes.draw do
     resources :users, only: %i[index show destroy]
     resources :send_letters, only: %i[index show destroy]
   end
+
+  namespace :demo do
+    root 'home#top'
+    get 'description', to: 'home#description'
+    get 'mypage', to: 'home#mypage'
+    get 'new_letter', to: 'letters#new'
+    get 'draft_letter', to: 'letters#draft'
+    get 'received_letter', to: 'letters#received'
+    get 'send_letter', to: 'letters#send'
+    get 'letter', to: 'letters#show'
+    resources :anniversaries, only: %i[index show]
+  end
 end


### PR DESCRIPTION
## 概要
ログインせずにアプリを体験できるようデモページを作成するため、初期設定を行いました。
- [x] デモページのルーティングを作成
- [x] デモページのコントローラーを作成
- [x] デモページのビューを作成

## 確認方法

1. https://www.future-letter.com/demo にアクセスできることをご確認ください。

## コメント
次回ビューの実装を行います。
