### PR TITLE
Fix：画像のサイズ制限を5MBから15MBへ拡大

### DIFF
--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -18,7 +18,7 @@ class ImageUploader < CarrierWave::Uploader::Base
   end
 
   def size_range
-    0..5.megabytes
+    0..15.megabytes
   end
 
   def filename


### PR DESCRIPTION
## 概要
画像のサイズ制限を5MBから15MBへ拡大しました。

## 確認方法
1. 5MB以上15MB以下の画像を選択することができることをご確認ください。