### PR TITLE
Add：手紙の数、記念日数を表示

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -9,7 +9,11 @@ class HomeController < ApplicationController
 
   def description; end
 
-  def mypage; end
+  def mypage
+    @send_letters = current_user.letters.joins(:send_letters)
+    @received_letters = Letter.joins(:send_letters).where(send_letters: { destination_id: current_user.id })
+    @anniversaries = Anniversary.where(user_id: current_user.id).includes(:user)
+  end
 
   def friend
     render layout: 'login'

--- a/app/javascript/packs/home/mypage.js
+++ b/app/javascript/packs/home/mypage.js
@@ -1,0 +1,33 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const token = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+
+  const LIFF_ID = process.env.LIFF_ID
+  liff.init({
+    liffId: LIFF_ID
+  })
+
+    .then(() => {
+      if (!liff.isLoggedIn()) {
+        liff.login()
+      }
+    })
+
+    .then(() => {
+      const idToken = liff.getIDToken()
+      const body = `idToken=${idToken}`
+      const request = new Request('/users', {
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8',
+          'X-CSRF-Token': token
+        },
+        method: 'POST',
+        body: body
+      });
+
+      fetch(request)
+        .then(response => response.json())
+        .then(data => {
+          data_id = data
+        })
+    })
+})

--- a/app/views/demo/anniversaries/trial.html.slim
+++ b/app/views/demo/anniversaries/trial.html.slim
@@ -1,2 +1,9 @@
-.text-blue-900.text-center.tracking-wider.main-font.text-base.py-3
+.text-blue-900.font.text-2xl.tracking-wider.text-center.py-6
+  = t('.title')
+
+.text-blue-900.text-center.tracking-wider.main-font.text-base.pb-6
   p ※ 現在準備中です。
+
+.text-blue-900.text-center.tracking-wider
+  .font.text-base
+    = link_to t('defaults.back'), demo_anniversaries_path

--- a/app/views/demo/letters/trial.html.slim
+++ b/app/views/demo/letters/trial.html.slim
@@ -1,2 +1,9 @@
-.text-blue-900.text-center.tracking-wider.main-font.text-base.py-3
+.text-blue-900.font.text-2xl.tracking-wider.text-center.py-6
+  = t('.title')
+
+.text-blue-900.text-center.tracking-wider.main-font.text-base.pb-6
   p ※ 現在準備中です。
+
+.text-blue-900.text-center.tracking-wider
+  .font.text-base
+    = link_to t('defaults.back'), demo_draft_letter_path

--- a/app/views/home/mypage.html.slim
+++ b/app/views/home/mypage.html.slim
@@ -32,7 +32,7 @@
             span.main-font
               | 通
       .pr-6
-        p 登録中の
+        p 登録した
         p 記念日の数
         - if @anniversaries.present?
           p.font.text-base
@@ -47,12 +47,14 @@
 
 .text-blue-900.main-font.text-1xl.tracking-wider.text-center.font-black
   .flex.justify-center.pb-3
-    = link_to t('.to_received_page'), received_path, class: "m-1 bg-blue-50 hover:bg-blue-100 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow"
+    .flex.justify-center.px-3
+      = link_to t('.to_received_page'), received_path, class: "m-1 bg-blue-50 hover:bg-blue-100 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow"
+    .flex.justify-center.px-3
+      = link_to t('.to_sent_letter_page'), send_letters_path, class: "m-1 bg-blue-50 hover:bg-blue-100 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow"
   .flex.justify-center.pb-3
-    = link_to t('.to_sent_letter_page'), send_letters_path, class: "m-1 bg-blue-50 hover:bg-blue-100 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow"
-  .flex.justify-center.pb-3
-    = link_to t('.to_anniversary_page'), anniversaries_path, class: "m-1 bg-blue-50 hover:bg-blue-100 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow"
-  .flex.justify-center.pb-3
-    = link_to t('.to_description_page'), description_path, class: "m-1 bg-blue-50 hover:bg-blue-100 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow"
+    .flex.justify-center.px-3
+      = link_to t('.to_anniversary_page'), anniversaries_path, class: "m-1 bg-blue-50 hover:bg-blue-100 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow"
+    .flex.justify-center.px-3
+      = link_to t('.to_description_page'), description_path, class: "m-1 bg-blue-50 hover:bg-blue-100 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow"
 
 = javascript_pack_tag 'home/mypage'

--- a/app/views/home/mypage.html.slim
+++ b/app/views/home/mypage.html.slim
@@ -1,6 +1,50 @@
 .text-blue-900.font.text-2xl.tracking-wider.text-center.py-6
   = t('.title')
 
+.px-2.pb-3
+  .main-font.text-base.text-blue-900.text-center.tracking-wider
+    p.pb-3 \ これまでの記録 /
+    .text-xs.px-4.flex.justify-center.pb-3
+      .px-6
+        p 送った
+        p 手紙の数
+        - if @send_letters.present?
+          p.font.text-base
+            = @send_letters.count
+            span.main-font
+              | 通
+        - else
+          p.font.text-base
+            | 0
+            span.main-font
+              | 通
+      .pr-6
+        p 受け取った
+        p 手紙の数
+        - if @received_letters.present?
+          p.font.text-base
+            = @received_letters.count
+            span.main-font
+              | 通
+        - else
+          p.font.text-base
+            | 0
+            span.main-font
+              | 通
+      .pr-6
+        p 登録中の
+        p 記念日の数
+        - if @anniversaries.present?
+          p.font.text-base
+            = @anniversaries.count
+            span.main-font
+              | 日
+        - else
+          p.font.text-base
+            | 0
+            span.main-font
+              | 日
+
 .text-blue-900.main-font.text-1xl.tracking-wider.text-center.font-black
   .flex.justify-center.pb-3
     = link_to t('.to_received_page'), received_path, class: "m-1 bg-blue-50 hover:bg-blue-100 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow"
@@ -10,3 +54,5 @@
     = link_to t('.to_anniversary_page'), anniversaries_path, class: "m-1 bg-blue-50 hover:bg-blue-100 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow"
   .flex.justify-center.pb-3
     = link_to t('.to_description_page'), description_path, class: "m-1 bg-blue-50 hover:bg-blue-100 text-blue-900 py-2 px-4 border border-blue-900 rounded-full shadow"
+
+= javascript_pack_tag 'home/mypage'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -73,6 +73,8 @@ ja:
       index:
         title: MY ANNIVERSARY
         to_register_page: 記念日を登録する
+      trial:
+        title: NEW ANNIVERSARY
     letters:
       draft:
         title: DRAFT LETTER
@@ -80,3 +82,5 @@ ja:
         title: SENT LETTER
       received:
         title: MY LETTER
+      trial:
+        title: NEW LETTER


### PR DESCRIPTION
## 概要
- 手紙・記念日の数を表示
マイページに送った手紙の数、受け取った手紙の数、登録した記念日の数を表示しました。 45352d70015eb80b0bde65dcee9cc27ec60c92e2
- UIの修正
デモの手紙作成ページ・記念日作成ページに「タイトル」と「一覧ページへ戻るボタン」を配置しました。 7f11c0f964eb6c48ddeefcc701a4a9604767f60d
マイページのボタンの配置を変更しました。 f321b4a67db61394c38e3b5c015340686ff26e5d
## 確認方法

1. マイページにログインユーザーが送った手紙の数、受け取った手紙の数、登録した記念日の数が表示されていること。
2. マイページ内のボタン4つが1列ではなくではなく2列で並んで表示されていること。