### PR TITLE
Add：送信者の名前を設定できる機能を追加

### DIFF
--- a/app/controllers/letters_controller.rb
+++ b/app/controllers/letters_controller.rb
@@ -77,7 +77,7 @@ class LettersController < ApplicationController
   private
 
   def letter_params
-    params.require(:letter).permit(:title, :body, :image, :remove_image, :user_id, :template_id, :token, :send_date)
+    params.require(:letter).permit(:title, :body, :image, :remove_image, :user_id, :template_id, :token, :send_date, :sender_name)
   end
 
   def set_letter

--- a/app/models/letter.rb
+++ b/app/models/letter.rb
@@ -6,6 +6,7 @@
 #  body        :text             not null
 #  image       :string
 #  send_date   :datetime         not null
+#  sender_name :string
 #  title       :string           not null
 #  token       :text             not null
 #  created_at  :datetime         not null
@@ -33,6 +34,7 @@ class Letter < ApplicationRecord
   validates :user_id, presence: true
   validates :title, presence: true, length: { maximum: 30 }
   validates :body, presence: true, length: { maximum: 1000 }
+  validates :sender_name, length: { maximum: 30 }
   validates :send_date, presence: true
   validates :token, presence: true
   validate :send_date_check

--- a/app/views/letters/_form.html.slim
+++ b/app/views/letters/_form.html.slim
@@ -25,6 +25,13 @@
       = f.text_area :body, class: "resize-none shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline", size: "20x8", placeholder: "手紙を書いたよ！〇〇〇より"
     .field.py-3.text-center
       .pb-2.font-black
+        = f.label :sender_name
+      .flex.items-center
+        = f.text_field :sender_name, class: "text-align:right shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline", placeholder: "〇〇〇"
+        span.pl-3.font-black
+          | より
+    .field.py-3.text-center
+      .pb-2.font-black
         = f.label :send_date
         br
       .font

--- a/app/views/send_letters/show.html.slim
+++ b/app/views/send_letters/show.html.slim
@@ -8,12 +8,17 @@ div id="letter-#{@letter.id}"
           = image_tag('default.jpg')
 
       .text-blue-900.main-font.text-1xl
-        .pt-6.px-3.text-center
+        .pt-6.px-6.text-center
           = @letter.title
           span.text-xs
             | へ
         .p-6.leading-5
           = safe_join(@letter.body.split("\n"),tag(:br))
+        - if @letter.sender_name.present?
+          .pb-6.px-6.text-right
+            = @letter.sender_name
+            span.text-xs
+              | より
 
   - if SendLetter.where(letter_id: @letter.id).where(destination_id: current_user.id).present?
     - if @letter.user == current_user

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -4,6 +4,7 @@ ja:
       letter:
         title: 手紙を送りたい相手の名前
         body: 手紙の本文
+        sender_name: 自分の名前
         image: 画像
         send_date: 手紙を送る日時
         remove_image: 画像を取り消す

--- a/db/migrate/20230209064435_add_sender_name_to_letters.rb
+++ b/db/migrate/20230209064435_add_sender_name_to_letters.rb
@@ -1,0 +1,5 @@
+class AddSenderNameToLetters < ActiveRecord::Migration[6.1]
+  def change
+    add_column :letters, :sender_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_17_051008) do
+ActiveRecord::Schema.define(version: 2023_02_09_064435) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,6 +35,7 @@ ActiveRecord::Schema.define(version: 2022_10_17_051008) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.datetime "send_date", null: false
+    t.string "sender_name"
     t.index ["template_id"], name: "index_letters_on_template_id"
     t.index ["user_id"], name: "index_letters_on_user_id"
   end

--- a/spec/factories/letters.rb
+++ b/spec/factories/letters.rb
@@ -6,6 +6,7 @@
 #  body        :text             not null
 #  image       :string
 #  send_date   :datetime         not null
+#  sender_name :string
 #  title       :string           not null
 #  token       :text             not null
 #  created_at  :datetime         not null
@@ -27,6 +28,7 @@ FactoryBot.define do
   factory :letter do
     title { Faker::Name.name }
     body { Faker::Lorem.sentence }
+    sender_name { Faker::Name.name }
     image { Rack::Test::UploadedFile.new(File.join(Rails.root, 'spec/fixtures/test.jpg')) }
     send_date { Time.current + 1.hours }
     token { SecureRandom.hex(32) }

--- a/spec/models/letter_spec.rb
+++ b/spec/models/letter_spec.rb
@@ -6,6 +6,7 @@
 #  body        :text             not null
 #  image       :string
 #  send_date   :datetime         not null
+#  sender_name :string
 #  title       :string           not null
 #  token       :text             not null
 #  created_at  :datetime         not null
@@ -44,7 +45,7 @@ RSpec.describe Letter, type: :model do
     end
 
     context '手紙の宛名が31文字以上の場合' do
-      it '記念日の作成が出来ないこと' do
+      it '手紙の作成が出来ないこと' do
         long_title_letter = Letter.new(title: Faker::Lorem.words(number: 31), body: Faker::Lorem.sentence, send_date: Time.current)
         expect(long_title_letter.valid?).to be false
         expect(long_title_letter.errors[:title]).to include('は30文字以内で入力してください')
@@ -52,10 +53,18 @@ RSpec.describe Letter, type: :model do
     end
 
     context '手紙の本文が1001文字以上の場合' do
-      it '記念日の作成が出来ないこと' do
+      it '手紙の作成が出来ないこと' do
         long_body_letter = Letter.new(title: Faker::Name.name, body: Faker::Lorem.sentence(word_count: 1001), send_date: Time.current)
         expect(long_body_letter.valid?).to be false
         expect(long_body_letter.errors[:body]).to include('は1000文字以内で入力してください')
+      end
+    end
+
+    context '手紙の送信者名が31文字以上の場合' do
+      it '手紙の作成が出来ないこと' do
+        long_sender_name_letter = Letter.new(title: Faker::Name.name, body: Faker::Lorem.sentence, send_date: Time.current, sender_name: Faker::Lorem.words(number: 31))
+        expect(long_sender_name_letter.valid?).to be false
+        expect(long_sender_name_letter.errors[:sender_name]).to include('は30文字以内で入力してください')
       end
     end
 


### PR DESCRIPTION
## 概要

- 手紙に送信者の名前を記載できる機能を追加しました。

## 確認方法
カラムを追加したので `bundle exec rails db:migrate` を実行してください。
以下、問題なく実行できることをご確認ください。
1. 手紙作成時に、「自分の名前」欄に送信者の名前を入力すると手紙の `sender_name`として保存されること。
2. 送信者の名前は設定しなくても手紙を送信できるが、文字数が30文字を超えると保存ができずエラーメッセージが表示されること。
3. 届いた手紙・送った手紙を開いた際、送信者の名前が設定されている手紙は送信者の名前が表示されること。